### PR TITLE
feat(#31): [milestone-2 review] P0: SplinkFuzzyMatcher does not use Splink

### DIFF
--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -22,6 +22,7 @@ from entity_registry.fuzzy import (
     FuzzyMatcher,
     FuzzyMatcherUnavailable,
     NullFuzzyMatcher,
+    SimpleFuzzyMatcher,
     SplinkFuzzyMatcher,
 )
 from entity_registry.llm_client import (
@@ -125,6 +126,7 @@ __all__ = [
     "ResolutionContext",
     "ResolutionDecision",
     "ResolutionMethod",
+    "SimpleFuzzyMatcher",
     "StockBasicRecord",
     "StockBasicSnapshotReader",
     "SplinkFuzzyMatcher",

--- a/src/entity_registry/fuzzy.py
+++ b/src/entity_registry/fuzzy.py
@@ -82,8 +82,75 @@ class NullFuzzyMatcher:
         return []
 
 
+class SimpleFuzzyMatcher:
+    """Local alias-table fuzzy matcher using deterministic text similarity."""
+
+    def __init__(
+        self,
+        *,
+        entity_repo: EntityRepository,
+        alias_repo: AliasRepository,
+        min_score: float = 0.80,
+        auto_resolve_score: float = 0.96,
+    ) -> None:
+        if min_score < 0.0 or min_score > 1.0:
+            raise ValueError("min_score must be between 0.0 and 1.0")
+        if auto_resolve_score < 0.0 or auto_resolve_score > 1.0:
+            raise ValueError("auto_resolve_score must be between 0.0 and 1.0")
+
+        self._entity_repo = entity_repo
+        self._alias_repo = alias_repo
+        self.min_score = min_score
+        self.auto_resolve_score = auto_resolve_score
+
+    def generate_candidates(
+        self,
+        raw_mention_text: str,
+        *,
+        context: "ResolutionContext | dict[str, object] | None" = None,
+        limit: int = 10,
+    ) -> list[FuzzyCandidate]:
+        if limit <= 0:
+            return []
+
+        raw_blocking_key = build_alias_blocking_key(raw_mention_text)
+        candidates: list[FuzzyCandidate] = []
+        for alias in self._alias_repo.list_all():
+            if self._entity_repo.get(alias.canonical_entity_id) is None:
+                continue
+
+            blocking_key = build_alias_blocking_key(alias.alias_text)
+            score = score_alias_similarity(raw_mention_text, alias.alias_text)
+            if (
+                raw_blocking_key
+                and blocking_key
+                and raw_blocking_key != blocking_key
+                and score < 1.0
+            ):
+                continue
+            if score < self.min_score:
+                continue
+
+            candidates.append(
+                FuzzyCandidate(
+                    canonical_entity_id=alias.canonical_entity_id,
+                    alias_text=alias.alias_text,
+                    alias_type=alias.alias_type,
+                    score=score,
+                    source="simple",
+                    blocking_key=blocking_key or None,
+                )
+            )
+
+        return _dedupe_sort_and_limit_candidates(candidates, limit)
+
+
 class SplinkFuzzyMatcher:
-    """Alias-table fuzzy matcher guarded by a lazy Splink availability check."""
+    """Splink-backed fuzzy matcher placeholder.
+
+    This adapter is intentionally separate from SimpleFuzzyMatcher so a caller
+    cannot accidentally get local difflib behavior from a Splink-named backend.
+    """
 
     def __init__(
         self,
@@ -114,37 +181,10 @@ class SplinkFuzzyMatcher:
         if limit <= 0:
             return []
         self._ensure_splink_available()
-
-        raw_blocking_key = build_alias_blocking_key(raw_mention_text)
-        candidates: list[FuzzyCandidate] = []
-        for alias in self._alias_repo.list_all():
-            if self._entity_repo.get(alias.canonical_entity_id) is None:
-                continue
-
-            blocking_key = build_alias_blocking_key(alias.alias_text)
-            score = score_alias_similarity(raw_mention_text, alias.alias_text)
-            if (
-                raw_blocking_key
-                and blocking_key
-                and raw_blocking_key != blocking_key
-                and score < 1.0
-            ):
-                continue
-            if score < self.min_score:
-                continue
-
-            candidates.append(
-                FuzzyCandidate(
-                    canonical_entity_id=alias.canonical_entity_id,
-                    alias_text=alias.alias_text,
-                    alias_type=alias.alias_type,
-                    score=score,
-                    source="splink",
-                    blocking_key=blocking_key or None,
-                )
-            )
-
-        return _dedupe_sort_and_limit_candidates(candidates, limit)
+        raise NotImplementedError(
+            "SplinkFuzzyMatcher requires a real Splink candidate generator; "
+            "use SimpleFuzzyMatcher for local heuristic matching",
+        )
 
     def _ensure_splink_available(self) -> None:
         if self._splink_checked:
@@ -154,7 +194,7 @@ class SplinkFuzzyMatcher:
         except ImportError as exc:
             raise FuzzyMatcherUnavailable(
                 "Splink is not installed; install entity-registry with the "
-                "'fuzzy' extra or use NullFuzzyMatcher"
+                "'fuzzy' extra or use SimpleFuzzyMatcher"
             ) from exc
         self._splink_checked = True
 
@@ -233,6 +273,7 @@ __all__ = [
     "FuzzyMatcher",
     "FuzzyMatcherUnavailable",
     "NullFuzzyMatcher",
+    "SimpleFuzzyMatcher",
     "SplinkFuzzyMatcher",
     "build_alias_blocking_key",
     "score_alias_similarity",

--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -10,6 +10,7 @@ from entity_registry.fuzzy import (
     FuzzyCandidate,
     FuzzyMatcherUnavailable,
     NullFuzzyMatcher,
+    SimpleFuzzyMatcher,
     SplinkFuzzyMatcher,
     build_alias_blocking_key,
     score_alias_similarity,
@@ -46,13 +47,14 @@ def fake_splink(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         fuzzy_module.importlib,
         "import_module",
-        lambda name: object(),
+        lambda name: object() if name == "splink" else None,
     )
 
 
 def test_package_exports_fuzzy_public_types() -> None:
     assert entity_registry.FuzzyCandidate is FuzzyCandidate
     assert entity_registry.NullFuzzyMatcher is NullFuzzyMatcher
+    assert entity_registry.SimpleFuzzyMatcher is SimpleFuzzyMatcher
     assert entity_registry.SplinkFuzzyMatcher is SplinkFuzzyMatcher
 
 
@@ -113,12 +115,11 @@ def test_splink_fuzzy_matcher_raises_when_backend_missing(
         matcher.generate_candidates("贵州茅台股份")
 
 
-def test_splink_fuzzy_matcher_sorts_and_dedupes_candidates_by_entity(
-    fake_splink: None,
+def test_simple_fuzzy_matcher_sorts_and_dedupes_candidates_by_entity(
     initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
 ) -> None:
     entity_repo, alias_repo = initialized_repositories
-    matcher = SplinkFuzzyMatcher(
+    matcher = SimpleFuzzyMatcher(
         entity_repo=entity_repo,
         alias_repo=alias_repo,
         min_score=0.75,
@@ -130,16 +131,15 @@ def test_splink_fuzzy_matcher_sorts_and_dedupes_candidates_by_entity(
         "ENT_STOCK_600519.SH"
     ]
     assert candidates[0].alias_text == "贵州茅台"
-    assert candidates[0].source == "splink"
+    assert candidates[0].source == "simple"
     assert candidates[0].score >= 0.8
 
 
-def test_splink_fuzzy_matcher_keeps_a_h_listings_as_separate_candidates(
-    fake_splink: None,
+def test_simple_fuzzy_matcher_keeps_a_h_listings_as_separate_candidates(
     initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
 ) -> None:
     entity_repo, alias_repo = initialized_repositories
-    matcher = SplinkFuzzyMatcher(
+    matcher = SimpleFuzzyMatcher(
         entity_repo=entity_repo,
         alias_repo=alias_repo,
         min_score=0.75,
@@ -154,12 +154,11 @@ def test_splink_fuzzy_matcher_keeps_a_h_listings_as_separate_candidates(
     assert len(candidates) == 2
 
 
-def test_splink_fuzzy_matcher_respects_limit(
-    fake_splink: None,
+def test_simple_fuzzy_matcher_respects_limit(
     initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
 ) -> None:
     entity_repo, alias_repo = initialized_repositories
-    matcher = SplinkFuzzyMatcher(
+    matcher = SimpleFuzzyMatcher(
         entity_repo=entity_repo,
         alias_repo=alias_repo,
         min_score=0.70,
@@ -168,3 +167,26 @@ def test_splink_fuzzy_matcher_respects_limit(
     candidates = matcher.generate_candidates("银行股份", limit=1)
 
     assert len(candidates) <= 1
+
+
+def test_splink_fuzzy_matcher_does_not_use_simple_heuristic_backend(
+    fake_splink: None,
+    monkeypatch: pytest.MonkeyPatch,
+    initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
+) -> None:
+    entity_repo, _ = initialized_repositories
+    alias_repo = ExplodingAliasRepository()
+
+    def fail_similarity(raw_mention_text: str, alias_text: str) -> float:
+        raise AssertionError("SplinkFuzzyMatcher must not call local similarity")
+
+    monkeypatch.setattr(fuzzy_module, "score_alias_similarity", fail_similarity)
+    matcher = SplinkFuzzyMatcher(entity_repo=entity_repo, alias_repo=alias_repo)
+
+    with pytest.raises(NotImplementedError, match="real Splink candidate generator"):
+        matcher.generate_candidates("贵州茅台股份")
+
+
+class ExplodingAliasRepository(InMemoryAliasRepository):
+    def list_all(self) -> list[object]:
+        raise AssertionError("SplinkFuzzyMatcher must not scan aliases locally")


### PR DESCRIPTION
Closes #31

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/__init__.py`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/resolution_types.py`, `tests/test_repository_hygiene.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
SplinkFuzzyMatcher only checks that the splink package can be imported, then scans alias_repo.list_all() and scores every alias with difflib.SequenceMatcher. This is not a Splink candidate generator and will not provide the blocking, comparison, or scaling properties promised by issue #7. The name and dependency check also hide the fact that the backend behavior is a local heuristic.

## 实现范围
- 修改文件: `src/entity_registry/fuzzy.py`
- Either implement a real Splink-backed matcher over the alias table, with explicit blocking/comparison configuration and tests that verify the Splink path is exercised, or rename the current implementation to SimpleFuzzyMatcher and keep it separate from a real SplinkFuzzyMatcher.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
