### PR TITLE
feat(#30): [milestone-2 review] P0: Public resolution path cannot run the full NER plus fuzzy plus LLM chain

### DIFF
--- a/src/entity_registry/init.py
+++ b/src/entity_registry/init.py
@@ -23,7 +23,9 @@ from entity_registry.core import (
     EntityType,
     generate_stock_entity_id,
 )
+from entity_registry.fuzzy import FuzzyMatcher
 from entity_registry.llm_client import ReasonerRuntimeClient
+from entity_registry.ner import NERExtractor
 from entity_registry.storage import (
     AliasRepository,
     EntityRepository,
@@ -189,6 +191,8 @@ class _RepositoryContext:
     alias_repo: AliasRepository
     reference_repo: ReferenceRepository | None = None
     case_repo: ResolutionCaseRepository | None = None
+    fuzzy_matcher: FuzzyMatcher | None = None
+    ner_extractor: NERExtractor | None = None
     reasoner_client: ReasonerRuntimeClient | None = None
 
 
@@ -210,6 +214,8 @@ def configure_default_repositories(
     *,
     reference_repo: ReferenceRepository | None = None,
     case_repo: ResolutionCaseRepository | None = None,
+    fuzzy_matcher: FuzzyMatcher | None = None,
+    ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
 ) -> None:
     """Configure repositories used by public package-level APIs.
@@ -224,6 +230,8 @@ def configure_default_repositories(
         alias_repo=alias_repo,
         reference_repo=reference_repo,
         case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+        ner_extractor=ner_extractor,
         reasoner_client=reasoner_client,
     )
     with _DEFAULT_REPOSITORY_CONTEXT_LOCK:
@@ -234,6 +242,8 @@ def configure_default_in_memory_audit_repositories(
     entity_repo: EntityRepository,
     alias_repo: AliasRepository,
     *,
+    fuzzy_matcher: FuzzyMatcher | None = None,
+    ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
 ) -> tuple[InMemoryReferenceRepository, InMemoryResolutionCaseRepository]:
     """Configure default repositories with explicit in-memory audit sinks.
@@ -249,6 +259,8 @@ def configure_default_in_memory_audit_repositories(
         alias_repo,
         reference_repo=reference_repo,
         case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+        ner_extractor=ner_extractor,
         reasoner_client=reasoner_client,
     )
     return reference_repo, case_repo

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -198,13 +198,20 @@ class DeterministicMatcher:
             )
         except Exception as exc:
             _LOGGER.exception("fuzzy candidate generation failed")
+            failure_rationale = f"fuzzy candidate generation failed: {exc}"
+            final_status, llm_required = _candidate_status(
+                deterministic_hits,
+                [],
+                {},
+                auto_resolve_threshold=_auto_resolve_threshold(fuzzy_matcher),
+            )
             return MentionCandidateSet(
                 raw_mention_text=raw_mention_text,
                 deterministic_hits=deterministic_hits,
                 fuzzy_hits=[],
-                llm_required=False,
-                final_status=FinalStatus.UNRESOLVED,
-                failure_rationale=f"fuzzy candidate generation failed: {exc}",
+                llm_required=llm_required,
+                final_status=final_status,
+                failure_rationale=failure_rationale,
             )
 
         fuzzy_hits = [candidate.canonical_entity_id for candidate in fuzzy_candidates]
@@ -370,6 +377,8 @@ def resolve_mention(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
+        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
+        ner_extractor=getattr(repository_context, "ner_extractor", None),
         reasoner_client=repository_context.reasoner_client,
     )
 
@@ -466,29 +475,49 @@ def _resolve_candidate_set_decision(
     if candidate_set.llm_required and candidate_entity_ids:
         if reasoner_client is None:
             return (
-                ResolutionDecision(
-                    selected_entity_id=None,
-                    method=ResolutionMethod.UNRESOLVED,
-                    confidence=None,
-                    rationale="reasoner client is not configured",
+                _attach_candidate_failure_rationale(
+                    ResolutionDecision(
+                        selected_entity_id=None,
+                        method=ResolutionMethod.UNRESOLVED,
+                        confidence=None,
+                        rationale="reasoner client is not configured",
+                    ),
+                    candidate_set.failure_rationale,
                 ),
                 DecisionType.MANUAL_REVIEW,
             )
         return (
-            _resolve_with_reasoner(
-                candidate_set,
-                context=context,
-                entity_repo=entity_repo,
-                reasoner_client=reasoner_client,
+            _attach_candidate_failure_rationale(
+                _resolve_with_reasoner(
+                    candidate_set,
+                    context=context,
+                    entity_repo=entity_repo,
+                    reasoner_client=reasoner_client,
+                ),
+                candidate_set.failure_rationale,
             ),
             DecisionType.LLM_ASSISTED,
         )
 
     return (
-        decision,
+        _attach_candidate_failure_rationale(
+            decision,
+            candidate_set.failure_rationale,
+        ),
         DecisionType.AUTO
         if not candidate_entity_ids
         else DecisionType.MANUAL_REVIEW,
+    )
+
+
+def _attach_candidate_failure_rationale(
+    decision: ResolutionDecision,
+    failure_rationale: str | None,
+) -> ResolutionDecision:
+    if failure_rationale is None or failure_rationale in decision.rationale:
+        return decision
+    return decision.model_copy(
+        update={"rationale": f"{decision.rationale}; {failure_rationale}"},
     )
 
 

--- a/tests/test_resolution_llm.py
+++ b/tests/test_resolution_llm.py
@@ -15,6 +15,7 @@ from entity_registry.llm_client import (
     LLMDisambiguationRequest,
     LLMDisambiguationResponse,
 )
+from entity_registry.ner import ExtractedMention
 from entity_registry.references import EntityReference, ResolutionCase
 from entity_registry.resolution import resolve_mention_with_repositories
 from entity_registry.storage import (
@@ -406,6 +407,72 @@ def test_public_resolve_mention_uses_configured_reasoner_client(
     )
 
 
+def test_public_resolve_mention_uses_configured_ner_fuzzy_and_reasoner(
+    initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
+) -> None:
+    entity_repo, alias_repo = initialized_repositories
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    fuzzy_matcher = RecordingFuzzyMatcher(
+        [
+            make_candidate(
+                "ENT_STOCK_03750.HK",
+                score=0.91,
+                alias_text="宁德时代新能源科技股份有限公司",
+            ),
+            make_candidate(
+                "ENT_STOCK_300750.SZ",
+                score=0.90,
+                alias_text="宁德时代新能源科技股份有限公司",
+            ),
+        ]
+    )
+    ner_extractor = StaticNERExtractor("宁德时代新能源")
+    reasoner_client = RecordingReasonerClient(
+        LLMDisambiguationResponse(
+            selected_entity_id="ENT_STOCK_03750.HK",
+            confidence=0.89,
+            rationale="HK market context",
+        )
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+        ner_extractor=ner_extractor,
+        reasoner_client=reasoner_client,
+    )
+
+    result = entity_registry.resolve_mention(
+        "公告称宁德时代新能源获增持",
+        {"market": "HK", "document_id": "doc-full-chain"},
+    )
+
+    references = list(reference_repo._references.values())
+    case = case_repo.find_by_reference(references[0].reference_id)[0]
+    assert result.model_dump(mode="json") == {
+        "raw_mention_text": "公告称宁德时代新能源获增持",
+        "resolved_entity_id": "ENT_STOCK_03750.HK",
+        "resolution_method": "llm",
+        "resolution_confidence": 0.89,
+    }
+    assert ner_extractor.calls == ["公告称宁德时代新能源获增持"]
+    assert fuzzy_matcher.calls == ["宁德时代新能源"]
+    assert [candidate.canonical_entity_id for candidate in reasoner_client.calls[0].candidates] == [
+        "ENT_STOCK_03750.HK",
+        "ENT_STOCK_300750.SZ",
+    ]
+    assert references[0].source_context == {
+        "market": "HK",
+        "document_id": "doc-full-chain",
+    }
+    assert references[0].resolution_method is ResolutionMethod.LLM
+    assert case.decision_type is DecisionType.LLM_ASSISTED
+    assert case.selected_entity_id == "ENT_STOCK_03750.HK"
+
+
 def test_public_resolve_mention_uses_one_default_context_snapshot(
     initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
     monkeypatch: pytest.MonkeyPatch,
@@ -511,6 +578,40 @@ def test_llm_audit_failure_propagates_without_delete(
     assert case_repo.find_by_reference("any") == []
 
 
+def test_ambiguous_deterministic_candidates_still_use_reasoner_when_fuzzy_fails(
+    initialized_repositories: tuple[InMemoryEntityRepository, InMemoryAliasRepository],
+) -> None:
+    entity_repo, alias_repo = initialized_repositories
+    audit_repo = CapturingAuditRepository()
+    reasoner_client = RecordingReasonerClient(
+        LLMDisambiguationResponse(
+            selected_entity_id="ENT_STOCK_300750.SZ",
+            confidence=0.86,
+            rationale="A-share context",
+        )
+    )
+
+    result = resolve_mention_with_repositories(
+        "宁德时代",
+        {"market": "A-share"},
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_repo=audit_repo,
+        fuzzy_matcher=FailingFuzzyMatcher(),
+        reasoner_client=reasoner_client,
+    )
+
+    assert result.resolution_method is ResolutionMethod.LLM
+    assert result.resolved_entity_id == "ENT_STOCK_300750.SZ"
+    assert len(reasoner_client.calls) == 1
+    assert audit_repo.cases[0].decision_type is DecisionType.LLM_ASSISTED
+    assert "A-share context" in audit_repo.cases[0].decision_rationale
+    assert (
+        "fuzzy candidate generation failed"
+        in audit_repo.cases[0].decision_rationale
+    )
+
+
 class RecordingFuzzyMatcher:
     auto_resolve_score = 0.96
 
@@ -527,6 +628,34 @@ class RecordingFuzzyMatcher:
     ) -> list[FuzzyCandidate]:
         self.calls.append(raw_mention_text)
         return self._candidates[:limit]
+
+
+class FailingFuzzyMatcher:
+    auto_resolve_score = 0.96
+
+    def generate_candidates(
+        self,
+        raw_mention_text: str,
+        *,
+        context: object = None,
+        limit: int = 10,
+    ) -> list[FuzzyCandidate]:
+        raise RuntimeError("fuzzy backend unavailable")
+
+
+class StaticNERExtractor:
+    def __init__(self, mention_text: str) -> None:
+        self._mention_text = mention_text
+        self.calls: list[str] = []
+
+    def extract_mentions(
+        self,
+        text: str,
+        *,
+        context: object = None,
+    ) -> list[ExtractedMention]:
+        self.calls.append(text)
+        return [ExtractedMention(mention_text=self._mention_text)]
 
 
 class RecordingReasonerClient:


### PR DESCRIPTION
Closes #30

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/resolution_types.py`, `tests/test_repository_hygiene.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The new fuzzy_matcher and ner_extractor are only accepted by resolve_mention_with_repositories(), while the public resolve_mention() path only pulls entity_repo, alias_repo, audit repos, and reasoner_client from the default repository context. There is no way to configure default NER or fuzzy components, so package-level resolve_mention() still skips #7 entirely and can only invoke LLM for ambiguous deterministic hits. That means the milestone's stated complete parsing chain is not available through the stable public API.

## 实现范围
- 修改文件: `src/entity_registry/resolution.py`
- Extend the default repository/context configuration to include fuzzy_matcher and ner_extractor, pass them from resolve_mention() into resolve_mention_with_repositories(), and add an integration test that exercises public resolve_mention() through deterministic miss -> NER extraction -> fuzzy candidates -> reasoner-runtime disambiguation -> audit writes.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
