### PR TITLE
feat(#9): 批量解析与未解析引用回补

### DIFF
--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -17,6 +17,13 @@ from entity_registry.aliases import (
     generate_aliases_from_stock_basic,
     lookup_alias,
 )
+from entity_registry.batch import (
+    BatchCandidateGroup,
+    BatchReferenceInput,
+    BatchResolutionOutcome,
+    BatchResolutionReport,
+    batch_resolve,
+)
 from entity_registry.fuzzy import (
     FuzzyCandidate,
     FuzzyMatcher,
@@ -90,7 +97,11 @@ __all__ = [
     "__version__",
     "AliasType",
     "AliasManager",
+    "BatchCandidateGroup",
+    "BatchReferenceInput",
     "BatchResolutionJob",
+    "BatchResolutionOutcome",
+    "BatchResolutionReport",
     "CallableReasonerRuntimeClient",
     "CanonicalEntity",
     "CanonicalEntityProfile",
@@ -130,6 +141,7 @@ __all__ = [
     "StockBasicRecord",
     "StockBasicSnapshotReader",
     "SplinkFuzzyMatcher",
+    "batch_resolve",
     "build_disambiguation_request",
     "configure_default_in_memory_audit_repositories",
     "configure_default_repositories",

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -1,0 +1,492 @@
+"""Batch orchestration for mention resolution and review routing."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, field_validator
+
+from entity_registry.aliases import normalize_alias_text
+from entity_registry.core import FinalStatus, ResolutionMethod
+from entity_registry.fuzzy import (
+    FuzzyCandidate,
+    FuzzyMatcher,
+    NullFuzzyMatcher,
+    build_alias_blocking_key,
+)
+from entity_registry.references import EntityReference
+from entity_registry.resolution import resolve_mention
+from entity_registry.resolution_types import (
+    BatchResolutionJob,
+    MentionResolutionResult,
+    ResolutionContext,
+)
+from entity_registry.storage import ReferenceRepository
+
+
+Resolver = Callable[
+    [str, ResolutionContext | dict[str, object] | None],
+    MentionResolutionResult,
+]
+
+
+class BatchReferenceInput(BaseModel):
+    """Normalized input for one batch resolution item."""
+
+    raw_mention_text: str
+    source_context: dict[str, object] = Field(default_factory=dict)
+    source_reference_id: str | None = None
+
+    @field_validator("raw_mention_text")
+    @classmethod
+    def validate_raw_mention_text(cls, value: str) -> str:
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("raw_mention_text must be a non-empty string")
+        return value
+
+
+class BatchCandidateGroup(BaseModel):
+    """Candidate group shared by one or more unresolved references."""
+
+    group_id: str
+    reference_ids: list[str]
+    raw_mentions: list[str]
+    candidate_entity_ids: list[str]
+    max_score: float | None
+    normalized_mention: str
+    blocking_key: str | None = None
+
+
+class BatchResolutionOutcome(BaseModel):
+    """Resolution outcome for one source reference input."""
+
+    source_reference_id: str | None
+    result: MentionResolutionResult
+    final_status: FinalStatus
+    error: str | None = None
+
+
+class BatchResolutionReport(BaseModel):
+    """Detailed batch result for schedulers and manual-review handoff."""
+
+    job: BatchResolutionJob
+    groups: list[BatchCandidateGroup]
+    outcomes: list[BatchResolutionOutcome]
+    resolved_reference_ids: list[str]
+    unresolved_reference_ids: list[str]
+    manual_review_reference_ids: list[str]
+    errors: list[str]
+
+
+def collect_unresolved_references(
+    reference_repo: ReferenceRepository,
+    *,
+    limit: int | None = None,
+) -> list[EntityReference]:
+    """Return unresolved references from a repository with stable ordering."""
+
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative")
+
+    unresolved = [
+        reference
+        for reference in reference_repo.find_unresolved()
+        if (
+            reference.resolution_method is ResolutionMethod.UNRESOLVED
+            and reference.resolved_entity_id is None
+        )
+    ]
+    unresolved.sort(key=lambda reference: (reference.created_at, reference.reference_id))
+
+    if limit is None:
+        return unresolved
+    return unresolved[:limit]
+
+
+def cluster_unresolved_references(
+    references: Sequence[EntityReference],
+    *,
+    fuzzy_matcher: FuzzyMatcher | None = None,
+    limit: int = 10,
+) -> list[BatchCandidateGroup]:
+    """Cluster unresolved references by mention text, blocking key, and candidates."""
+
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+
+    matcher = fuzzy_matcher if fuzzy_matcher is not None else NullFuzzyMatcher()
+    groups_by_key: dict[tuple[str, str | None, tuple[str, ...]], BatchCandidateGroup] = {}
+
+    for reference in references:
+        candidates = matcher.generate_candidates(
+            reference.raw_mention_text,
+            context=reference.source_context,
+            limit=limit,
+        )
+        candidate_entity_ids = _candidate_entity_ids(candidates)
+        normalized_mention = _normalize_group_mention(reference.raw_mention_text)
+        blocking_key = _blocking_key_for(reference.raw_mention_text, candidates)
+        group_key = (
+            normalized_mention,
+            blocking_key,
+            tuple(sorted(candidate_entity_ids)),
+        )
+
+        group = groups_by_key.get(group_key)
+        if group is None:
+            group = BatchCandidateGroup(
+                group_id=_group_id(group_key),
+                reference_ids=[],
+                raw_mentions=[],
+                candidate_entity_ids=candidate_entity_ids,
+                max_score=_max_score(candidates),
+                normalized_mention=normalized_mention,
+                blocking_key=blocking_key,
+            )
+            groups_by_key[group_key] = group
+
+        if reference.reference_id not in group.reference_ids:
+            group.reference_ids.append(reference.reference_id)
+        if reference.raw_mention_text not in group.raw_mentions:
+            group.raw_mentions.append(reference.raw_mention_text)
+        group.max_score = _max_group_score(group.max_score, _max_score(candidates))
+
+    return sorted(
+        groups_by_key.values(),
+        key=lambda group: (
+            group.normalized_mention,
+            group.blocking_key or "",
+            group.group_id,
+        ),
+    )
+
+
+def run_batch_resolution_job(
+    job: BatchResolutionJob,
+    references: Sequence[EntityReference | dict[str, object] | str],
+    *,
+    resolver: Resolver | None = None,
+) -> BatchResolutionReport:
+    """Run one batch job by delegating every unique source reference to a resolver."""
+
+    active_resolver = resolver if resolver is not None else resolve_mention
+    inputs = [_coerce_reference_input(reference) for reference in references]
+    job.reference_ids = _unique_ids([
+        item.source_reference_id
+        for item in inputs
+        if item.source_reference_id is not None
+    ])
+    _mark_job_running(job)
+
+    outcomes: list[BatchResolutionOutcome] = []
+    errors: list[str] = []
+    outcomes_by_reference_id: dict[str, BatchResolutionOutcome] = {}
+
+    for item in inputs:
+        cached = (
+            outcomes_by_reference_id.get(item.source_reference_id)
+            if item.source_reference_id is not None
+            else None
+        )
+        if cached is not None:
+            outcomes.append(cached.model_copy(deep=True))
+            continue
+
+        outcome = _resolve_one(item, active_resolver)
+        if outcome.error is not None:
+            errors.append(_outcome_error_message(outcome))
+        if item.source_reference_id is not None:
+            outcomes_by_reference_id[item.source_reference_id] = outcome
+        outcomes.append(outcome)
+
+    groups = cluster_unresolved_references(
+        [
+            reference
+            for reference in references
+            if isinstance(reference, EntityReference)
+            and reference.resolution_method is ResolutionMethod.UNRESOLVED
+            and reference.resolved_entity_id is None
+        ]
+    )
+    resolved_reference_ids = _resolved_reference_ids(outcomes)
+    unresolved_reference_ids = _unresolved_reference_ids(outcomes)
+    manual_review_reference_ids = _manual_review_reference_ids(outcomes)
+
+    if errors:
+        _mark_job_failed(job, errors[0])
+    else:
+        _mark_job_completed(job)
+
+    return BatchResolutionReport(
+        job=job,
+        groups=groups,
+        outcomes=outcomes,
+        resolved_reference_ids=resolved_reference_ids,
+        unresolved_reference_ids=unresolved_reference_ids,
+        manual_review_reference_ids=manual_review_reference_ids,
+        errors=errors,
+    )
+
+
+def batch_resolve(
+    references: Sequence[EntityReference | dict[str, object] | str],
+) -> list[MentionResolutionResult]:
+    """Resolve a batch of mentions and return the stable public result shape."""
+
+    normalized_inputs = [_coerce_reference_input(reference) for reference in references]
+    job = BatchResolutionJob(
+        job_id=_new_job_id(),
+        reference_ids=_unique_ids([
+            item.source_reference_id
+            for item in normalized_inputs
+            if item.source_reference_id is not None
+        ]),
+        status="pending",
+    )
+    report = run_batch_resolution_job(job, normalized_inputs)
+    return [outcome.result for outcome in report.outcomes]
+
+
+def _coerce_reference_input(
+    reference: EntityReference | BatchReferenceInput | dict[str, object] | str,
+) -> BatchReferenceInput:
+    if isinstance(reference, BatchReferenceInput):
+        return reference
+    if isinstance(reference, EntityReference):
+        return BatchReferenceInput(
+            raw_mention_text=reference.raw_mention_text,
+            source_context=dict(reference.source_context),
+            source_reference_id=reference.reference_id,
+        )
+    if isinstance(reference, str):
+        return BatchReferenceInput(raw_mention_text=reference)
+    if isinstance(reference, dict):
+        payload = dict(reference)
+        source_context = payload.get("source_context", {})
+        if source_context is None:
+            source_context = {}
+        if not isinstance(source_context, dict):
+            raise ValueError("source_context must be a dictionary")
+
+        source_reference_id = payload.get("source_reference_id")
+        if source_reference_id is None:
+            source_reference_id = payload.get("reference_id")
+        if source_reference_id is not None and not isinstance(source_reference_id, str):
+            raise ValueError("source_reference_id must be a string when provided")
+
+        return BatchReferenceInput(
+            raw_mention_text=_required_text(payload, "raw_mention_text"),
+            source_context=dict(source_context),
+            source_reference_id=source_reference_id,
+        )
+    raise TypeError("batch references must be EntityReference, dict, or str")
+
+
+def _resolve_one(
+    item: BatchReferenceInput,
+    resolver: Resolver,
+) -> BatchResolutionOutcome:
+    try:
+        result = resolver(item.raw_mention_text, item.source_context)
+        if not isinstance(result, MentionResolutionResult):
+            result = MentionResolutionResult.model_validate(result)
+    except Exception as exc:
+        result = MentionResolutionResult(
+            raw_mention_text=item.raw_mention_text,
+            resolved_entity_id=None,
+            resolution_method=ResolutionMethod.UNRESOLVED,
+            resolution_confidence=None,
+        )
+        return BatchResolutionOutcome(
+            source_reference_id=item.source_reference_id,
+            result=result,
+            final_status=FinalStatus.UNRESOLVED,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    return BatchResolutionOutcome(
+        source_reference_id=item.source_reference_id,
+        result=result,
+        final_status=_final_status_for(result),
+        error=None,
+    )
+
+
+def _final_status_for(result: MentionResolutionResult) -> FinalStatus:
+    if (
+        result.resolved_entity_id is not None
+        and result.resolution_method
+        in {
+            ResolutionMethod.DETERMINISTIC,
+            ResolutionMethod.FUZZY,
+            ResolutionMethod.LLM,
+            ResolutionMethod.MANUAL,
+        }
+    ):
+        return FinalStatus.RESOLVED
+    return FinalStatus.UNRESOLVED
+
+
+def _resolved_reference_ids(outcomes: Sequence[BatchResolutionOutcome]) -> list[str]:
+    return _unique_ids([
+        outcome.source_reference_id
+        for outcome in outcomes
+        if outcome.source_reference_id is not None
+        if outcome.final_status is FinalStatus.RESOLVED
+    ])
+
+
+def _unresolved_reference_ids(outcomes: Sequence[BatchResolutionOutcome]) -> list[str]:
+    return _unique_ids([
+        outcome.source_reference_id
+        for outcome in outcomes
+        if outcome.source_reference_id is not None
+        if outcome.result.resolved_entity_id is None
+    ])
+
+
+def _manual_review_reference_ids(
+    outcomes: Sequence[BatchResolutionOutcome],
+) -> list[str]:
+    return _unique_ids([
+        outcome.source_reference_id
+        for outcome in outcomes
+        if outcome.source_reference_id is not None
+        if (
+            outcome.final_status is FinalStatus.MANUAL_REVIEW
+            or outcome.result.resolved_entity_id is None
+            or outcome.error is not None
+        )
+    ])
+
+
+def _unique_ids(reference_ids: Sequence[str]) -> list[str]:
+    unique: list[str] = []
+    for reference_id in reference_ids:
+        if reference_id not in unique:
+            unique.append(reference_id)
+    return unique
+
+
+def _required_text(payload: dict[str, object], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _candidate_entity_ids(candidates: Sequence[FuzzyCandidate]) -> list[str]:
+    best_by_entity: dict[str, FuzzyCandidate] = {}
+    for candidate in candidates:
+        current = best_by_entity.get(candidate.canonical_entity_id)
+        if current is None or _candidate_sort_key(candidate) < _candidate_sort_key(
+            current
+        ):
+            best_by_entity[candidate.canonical_entity_id] = candidate
+
+    return [
+        candidate.canonical_entity_id
+        for candidate in sorted(best_by_entity.values(), key=_candidate_sort_key)
+    ]
+
+
+def _candidate_sort_key(candidate: FuzzyCandidate) -> tuple[float, str, str]:
+    return (-candidate.score, candidate.canonical_entity_id, candidate.alias_text)
+
+
+def _normalize_group_mention(raw_mention_text: str) -> str:
+    return normalize_alias_text(raw_mention_text).casefold()
+
+
+def _blocking_key_for(
+    raw_mention_text: str,
+    candidates: Sequence[FuzzyCandidate],
+) -> str | None:
+    blocking_keys = sorted(
+        {
+            candidate.blocking_key
+            for candidate in candidates
+            if candidate.blocking_key
+        }
+    )
+    if blocking_keys:
+        return "|".join(blocking_keys)
+
+    fallback = build_alias_blocking_key(raw_mention_text)
+    return fallback[:4] or None
+
+
+def _max_score(candidates: Sequence[FuzzyCandidate]) -> float | None:
+    if not candidates:
+        return None
+    return max(candidate.score for candidate in candidates)
+
+
+def _max_group_score(
+    current: float | None,
+    incoming: float | None,
+) -> float | None:
+    if current is None:
+        return incoming
+    if incoming is None:
+        return current
+    return max(current, incoming)
+
+
+def _group_id(group_key: tuple[str, str | None, tuple[str, ...]]) -> str:
+    payload = "|".join(
+        [
+            group_key[0],
+            group_key[1] or "",
+            ",".join(group_key[2]),
+        ]
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:12]
+    return f"BCG_{digest}"
+
+
+def _outcome_error_message(outcome: BatchResolutionOutcome) -> str:
+    source = outcome.source_reference_id or outcome.result.raw_mention_text
+    return f"{source}: {outcome.error}"
+
+
+def _mark_job_running(job: BatchResolutionJob) -> None:
+    job.status = "running"
+    job.started_at = _utcnow()
+    job.completed_at = None
+    job.error_summary = None
+
+
+def _mark_job_completed(job: BatchResolutionJob) -> None:
+    job.status = "completed"
+    job.completed_at = _utcnow()
+    job.error_summary = None
+
+
+def _mark_job_failed(job: BatchResolutionJob, error_summary: str) -> None:
+    job.status = "failed"
+    job.completed_at = _utcnow()
+    job.error_summary = error_summary[:500]
+
+
+def _new_job_id() -> str:
+    return f"BATCH_{uuid4().hex}"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+__all__ = [
+    "BatchCandidateGroup",
+    "BatchReferenceInput",
+    "BatchResolutionOutcome",
+    "BatchResolutionReport",
+    "batch_resolve",
+    "cluster_unresolved_references",
+    "collect_unresolved_references",
+    "run_batch_resolution_job",
+]

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -166,7 +166,9 @@ def cluster_unresolved_references(
 
 def run_batch_resolution_job(
     job: BatchResolutionJob,
-    references: Sequence[EntityReference | dict[str, object] | str],
+    references: Sequence[
+        EntityReference | BatchReferenceInput | dict[str, object] | str
+    ],
     *,
     resolver: Resolver | None = None,
 ) -> BatchResolutionReport:
@@ -203,13 +205,7 @@ def run_batch_resolution_job(
         outcomes.append(outcome)
 
     groups = cluster_unresolved_references(
-        [
-            reference
-            for reference in references
-            if isinstance(reference, EntityReference)
-            and reference.resolution_method is ResolutionMethod.UNRESOLVED
-            and reference.resolved_entity_id is None
-        ]
+        _candidate_group_references(inputs, outcomes)
     )
     resolved_reference_ids = _resolved_reference_ids(outcomes)
     unresolved_reference_ids = _unresolved_reference_ids(outcomes)
@@ -247,6 +243,10 @@ def batch_resolve(
         status="pending",
     )
     report = run_batch_resolution_job(job, normalized_inputs)
+    if report.errors:
+        raise RuntimeError(
+            "batch resolution failed: " + "; ".join(report.errors),
+        )
     return [outcome.result for outcome in report.outcomes]
 
 
@@ -327,7 +327,39 @@ def _final_status_for(result: MentionResolutionResult) -> FinalStatus:
         }
     ):
         return FinalStatus.RESOLVED
+    # FinalStatus.MANUAL_REVIEW is reserved for the persistent review queue in #10.
+    # This batch layer routes unresolved/error outcomes to manual_review_reference_ids.
     return FinalStatus.UNRESOLVED
+
+
+def _candidate_group_references(
+    inputs: Sequence[BatchReferenceInput],
+    outcomes: Sequence[BatchResolutionOutcome],
+) -> list[EntityReference]:
+    references: list[EntityReference] = []
+    for index, (item, outcome) in enumerate(zip(inputs, outcomes, strict=True)):
+        if not _routes_to_manual_review(outcome):
+            continue
+
+        references.append(
+            EntityReference(
+                reference_id=item.source_reference_id or f"batch-input:{index}",
+                raw_mention_text=item.raw_mention_text,
+                source_context=dict(item.source_context),
+                resolved_entity_id=outcome.result.resolved_entity_id,
+                resolution_method=outcome.result.resolution_method,
+                resolution_confidence=outcome.result.resolution_confidence,
+            )
+        )
+    return references
+
+
+def _routes_to_manual_review(outcome: BatchResolutionOutcome) -> bool:
+    return (
+        outcome.final_status is FinalStatus.MANUAL_REVIEW
+        or outcome.result.resolved_entity_id is None
+        or outcome.error is not None
+    )
 
 
 def _resolved_reference_ids(outcomes: Sequence[BatchResolutionOutcome]) -> list[str]:
@@ -355,11 +387,7 @@ def _manual_review_reference_ids(
         outcome.source_reference_id
         for outcome in outcomes
         if outcome.source_reference_id is not None
-        if (
-            outcome.final_status is FinalStatus.MANUAL_REVIEW
-            or outcome.result.resolved_entity_id is None
-            or outcome.error is not None
-        )
+        if _routes_to_manual_review(outcome)
     ])
 
 

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -18,7 +19,10 @@ from entity_registry.fuzzy import (
     build_alias_blocking_key,
 )
 from entity_registry.references import EntityReference
-from entity_registry.resolution import resolve_mention
+from entity_registry.resolution import (
+    resolve_mention,
+    resolve_mention_with_repositories,
+)
 from entity_registry.resolution_types import (
     BatchResolutionJob,
     MentionResolutionResult,
@@ -27,8 +31,10 @@ from entity_registry.resolution_types import (
 from entity_registry.storage import ReferenceRepository
 
 
+_DEFAULT_RESOLVE_MENTION = resolve_mention
+
 Resolver = Callable[
-    [str, ResolutionContext | dict[str, object] | None],
+    ...,
     MentionResolutionResult,
 ]
 
@@ -171,10 +177,11 @@ def run_batch_resolution_job(
     ],
     *,
     resolver: Resolver | None = None,
+    fuzzy_matcher: FuzzyMatcher | None = None,
 ) -> BatchResolutionReport:
     """Run one batch job by delegating every unique source reference to a resolver."""
 
-    active_resolver = resolver if resolver is not None else resolve_mention
+    active_resolver = resolver if resolver is not None else _resolve_mention_for_batch
     inputs = [_coerce_reference_input(reference) for reference in references]
     job.reference_ids = _unique_ids([
         item.source_reference_id
@@ -205,7 +212,8 @@ def run_batch_resolution_job(
         outcomes.append(outcome)
 
     groups = cluster_unresolved_references(
-        _candidate_group_references(inputs, outcomes)
+        _candidate_group_references(inputs, outcomes),
+        fuzzy_matcher=fuzzy_matcher,
     )
     resolved_reference_ids = _resolved_reference_ids(outcomes)
     unresolved_reference_ids = _unresolved_reference_ids(outcomes)
@@ -290,7 +298,7 @@ def _resolve_one(
     resolver: Resolver,
 ) -> BatchResolutionOutcome:
     try:
-        result = resolver(item.raw_mention_text, item.source_context)
+        result = _call_resolver(resolver, item)
         if not isinstance(result, MentionResolutionResult):
             result = MentionResolutionResult.model_validate(result)
     except Exception as exc:
@@ -312,6 +320,78 @@ def _resolve_one(
         result=result,
         final_status=_final_status_for(result),
         error=None,
+    )
+
+
+def _call_resolver(
+    resolver: Resolver,
+    item: BatchReferenceInput,
+) -> MentionResolutionResult:
+    if (
+        item.source_reference_id is not None
+        and _resolver_accepts_existing_reference_id(resolver)
+    ):
+        return resolver(
+            item.raw_mention_text,
+            item.source_context,
+            existing_reference_id=item.source_reference_id,
+        )
+    return resolver(item.raw_mention_text, item.source_context)
+
+
+def _resolve_mention_for_batch(
+    raw_mention_text: str,
+    context: ResolutionContext | dict[str, object] | None = None,
+    *,
+    existing_reference_id: str | None = None,
+) -> MentionResolutionResult:
+    if resolve_mention is not _DEFAULT_RESOLVE_MENTION:
+        return resolve_mention(raw_mention_text, context)
+
+    if existing_reference_id is None:
+        return resolve_mention(raw_mention_text, context)
+
+    from entity_registry.init import (
+        RepositoryNotConfiguredError,
+        _get_default_repository_context,
+    )
+
+    repository_context = _get_default_repository_context()
+    if (
+        repository_context.reference_repo is None
+        or repository_context.case_repo is None
+    ):
+        raise RepositoryNotConfiguredError(
+            "resolution audit repositories are not configured; "
+            "call configure_default_repositories(..., reference_repo=..., "
+            "case_repo=...) before using public resolution APIs, or use "
+            "configure_default_in_memory_audit_repositories() for tests/local workflows",
+        )
+
+    return resolve_mention_with_repositories(
+        raw_mention_text,
+        context,
+        entity_repo=repository_context.entity_repo,
+        alias_repo=repository_context.alias_repo,
+        reference_repo=repository_context.reference_repo,
+        case_repo=repository_context.case_repo,
+        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
+        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        reasoner_client=repository_context.reasoner_client,
+        existing_reference_id=existing_reference_id,
+    )
+
+
+def _resolver_accepts_existing_reference_id(resolver: Resolver) -> bool:
+    try:
+        parameters = inspect.signature(resolver).parameters
+    except (TypeError, ValueError):
+        return False
+
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or name == "existing_reference_id"
+        for name, parameter in parameters.items()
     )
 
 

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -395,8 +395,12 @@ def resolve_mention_with_repositories(
     fuzzy_matcher: FuzzyMatcher | None = None,
     ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
+    existing_reference_id: str | None = None,
 ) -> MentionResolutionResult:
     """Resolve one mention using explicit repositories and write audit records."""
+
+    if existing_reference_id is not None and not existing_reference_id.strip():
+        raise ValueError("existing_reference_id must be a non-empty string")
 
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(
@@ -423,14 +427,23 @@ def resolve_mention_with_repositories(
     resolution_confidence = decision.confidence if resolved_entity_id is not None else None
     candidate_entity_ids = _candidate_entity_ids(candidate_set)
 
-    reference = EntityReference(
-        reference_id=_new_reference_id(),
-        raw_mention_text=raw_mention_text,
-        source_context=source_context,
-        resolved_entity_id=resolved_entity_id,
-        resolution_method=resolution_method,
-        resolution_confidence=resolution_confidence,
+    existing_reference = (
+        reference_repo.get(existing_reference_id)
+        if existing_reference_id is not None and reference_repo is not None
+        else None
     )
+    reference_payload = {
+        "reference_id": existing_reference_id or _new_reference_id(),
+        "raw_mention_text": raw_mention_text,
+        "source_context": source_context,
+        "resolved_entity_id": resolved_entity_id,
+        "resolution_method": resolution_method,
+        "resolution_confidence": resolution_confidence,
+    }
+    if existing_reference is not None:
+        reference_payload["created_at"] = existing_reference.created_at
+
+    reference = EntityReference(**reference_payload)
     case = ResolutionCase(
         case_id=_new_case_id(),
         reference_id=reference.reference_id,

--- a/src/entity_registry/resolution_types.py
+++ b/src/entity_registry/resolution_types.py
@@ -82,4 +82,6 @@ class BatchResolutionJob(BaseModel):
     reference_ids: list[str]
     status: str
     created_at: datetime = Field(default_factory=_utcnow)
+    started_at: datetime | None = None
     completed_at: datetime | None = None
+    error_summary: str | None = None

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -306,6 +306,85 @@ def test_run_batch_resolution_job_builds_groups_for_dict_and_string_inputs() -> 
     assert report.manual_review_reference_ids == ["ref-dict"]
 
 
+def test_backfill_resolution_updates_original_unresolved_reference_id() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    source = make_reference(
+        "ref-backfill",
+        "贵州茅台",
+        {"document_id": "doc-backfill"},
+    )
+    reference_repo.save(source)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+    job = BatchResolutionJob(job_id="job-backfill", reference_ids=[], status="pending")
+
+    report = run_batch_resolution_job(
+        job,
+        collect_unresolved_references(reference_repo),
+    )
+
+    updated = reference_repo.get("ref-backfill")
+    assert updated is not None
+    assert updated.resolved_entity_id == "ENT_STOCK_600519.SH"
+    assert updated.resolution_method is ResolutionMethod.DETERMINISTIC
+    assert updated.source_context == {"document_id": "doc-backfill"}
+    assert updated.created_at == source.created_at
+    assert reference_repo.find_unresolved() == []
+    assert list(reference_repo._references) == ["ref-backfill"]
+    assert case_repo.find_by_reference("ref-backfill")[0].selected_entity_id == (
+        "ENT_STOCK_600519.SH"
+    )
+    assert report.resolved_reference_ids == ["ref-backfill"]
+    assert report.manual_review_reference_ids == []
+
+
+def test_run_batch_resolution_job_threads_fuzzy_matcher_into_manual_review_groups() -> None:
+    def resolver(
+        raw_mention_text: str,
+        context: object = None,
+    ) -> MentionResolutionResult:
+        return unresolved_result(raw_mention_text)
+
+    matcher = RecordingFuzzyMatcher(
+        {
+            "Ambiguous Co": [
+                make_candidate("ENT_STOCK_000001.SZ", score=0.71, alias_text="Ambiguous"),
+                make_candidate("ENT_STOCK_000002.SZ", score=0.69, alias_text="Ambiguous"),
+            ]
+        }
+    )
+    job = BatchResolutionJob(
+        job_id="job-manual-review-groups",
+        reference_ids=[],
+        status="pending",
+    )
+
+    report = run_batch_resolution_job(
+        job,
+        [{"reference_id": "ref-ambiguous", "raw_mention_text": "Ambiguous Co"}],
+        resolver=resolver,
+        fuzzy_matcher=matcher,
+    )
+
+    assert len(report.groups) == 1
+    assert report.groups[0].reference_ids == ["ref-ambiguous"]
+    assert report.groups[0].candidate_entity_ids == [
+        "ENT_STOCK_000001.SZ",
+        "ENT_STOCK_000002.SZ",
+    ]
+    assert report.groups[0].max_score == 0.71
+    assert matcher.calls == [
+        ("Ambiguous Co", {"limit": 10, "context": {}}),
+    ]
+    assert report.manual_review_reference_ids == ["ref-ambiguous"]
+
+
 def test_public_batch_resolve_uses_configured_ner_fuzzy_reasoner_and_audit() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -28,7 +28,7 @@ from entity_registry.llm_client import (
     LLMDisambiguationResponse,
 )
 from entity_registry.ner import ExtractedMention
-from entity_registry.references import EntityReference
+from entity_registry.references import EntityReference, ResolutionCase
 from entity_registry.resolution_types import BatchResolutionJob, MentionResolutionResult
 from entity_registry.storage import (
     InMemoryAliasRepository,
@@ -102,6 +102,29 @@ def test_batch_resolve_normalizes_supported_inputs_and_preserves_order(
         ("Dict Co", {"document_id": "doc-1", "offset": 9}),
         ("Bare Co", {}),
     ]
+
+
+def test_batch_resolve_raises_when_default_repositories_are_not_configured() -> None:
+    with pytest.raises(RuntimeError, match="RepositoryNotConfiguredError"):
+        batch_resolve(["Unconfigured Co"])
+
+
+def test_batch_resolve_raises_on_audit_write_failure() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = FailingAuditReferenceRepository(case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(RuntimeError, match="audit failed"):
+        batch_resolve(["Unknown Co"])
+
+    assert reference_repo._references == {}
+    assert case_repo._cases == {}
 
 
 def test_collect_unresolved_references_filters_sorts_and_limits() -> None:
@@ -245,6 +268,42 @@ def test_run_batch_resolution_job_keeps_completed_outcomes_when_one_item_fails()
     assert report.resolved_reference_ids == ["ref-ok"]
     assert report.unresolved_reference_ids == ["ref-bad"]
     assert report.manual_review_reference_ids == ["ref-bad"]
+
+
+def test_run_batch_resolution_job_builds_groups_for_dict_and_string_inputs() -> None:
+    def resolver(
+        raw_mention_text: str,
+        context: object = None,
+    ) -> MentionResolutionResult:
+        return unresolved_result(raw_mention_text)
+
+    job = BatchResolutionJob(job_id="job-groups", reference_ids=[], status="pending")
+    report = run_batch_resolution_job(
+        job,
+        [
+            {
+                "reference_id": "ref-dict",
+                "raw_mention_text": "Dict Missing",
+                "source_context": {"document_id": "doc-1"},
+            },
+            "Bare Missing",
+        ],
+        resolver=resolver,
+    )
+
+    group_reference_ids = {
+        reference_id
+        for group in report.groups
+        for reference_id in group.reference_ids
+    }
+    group_mentions = {
+        raw_mention
+        for group in report.groups
+        for raw_mention in group.raw_mentions
+    }
+    assert group_reference_ids == {"ref-dict", "batch-input:1"}
+    assert group_mentions == {"Dict Missing", "Bare Missing"}
+    assert report.manual_review_reference_ids == ["ref-dict"]
 
 
 def test_public_batch_resolve_uses_configured_ner_fuzzy_reasoner_and_audit() -> None:
@@ -476,6 +535,15 @@ class RecordingFuzzyMatcher:
             )
         )
         return self._candidates_by_text.get(raw_mention_text, [])[:limit]
+
+
+class FailingAuditReferenceRepository(InMemoryResolutionAuditReferenceRepository):
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None:
+        raise RuntimeError("audit failed")
 
 
 class StaticNERExtractor:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,506 @@
+import inspect
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import entity_registry
+import entity_registry.batch as batch_module
+from entity_registry.batch import (
+    BatchCandidateGroup,
+    BatchReferenceInput,
+    BatchResolutionOutcome,
+    BatchResolutionReport,
+    batch_resolve,
+    cluster_unresolved_references,
+    collect_unresolved_references,
+    run_batch_resolution_job,
+)
+from entity_registry.core import AliasType, FinalStatus, ResolutionMethod
+from entity_registry.fuzzy import FuzzyCandidate
+from entity_registry.init import (
+    FileStockBasicSnapshotReader,
+    initialize_from_stock_basic_into,
+)
+from entity_registry.llm_client import (
+    LLMDisambiguationRequest,
+    LLMDisambiguationResponse,
+)
+from entity_registry.ner import ExtractedMention
+from entity_registry.references import EntityReference
+from entity_registry.resolution_types import BatchResolutionJob, MentionResolutionResult
+from entity_registry.storage import (
+    InMemoryAliasRepository,
+    InMemoryEntityRepository,
+    InMemoryReferenceRepository,
+    InMemoryResolutionAuditReferenceRepository,
+    InMemoryResolutionCaseRepository,
+)
+
+
+FIXTURE_PATH = Path("tests/fixtures/stock_basic_sample.json")
+
+
+@pytest.fixture(autouse=True)
+def reset_public_repositories() -> Iterator[None]:
+    entity_registry.reset_default_repositories()
+    yield
+    entity_registry.reset_default_repositories()
+
+
+def test_batch_resolve_public_signature_and_exports() -> None:
+    signature = inspect.signature(batch_resolve)
+
+    assert list(signature.parameters) == ["references"]
+    assert entity_registry.batch_resolve is batch_resolve
+    assert entity_registry.BatchReferenceInput is BatchReferenceInput
+    assert entity_registry.BatchCandidateGroup is BatchCandidateGroup
+    assert entity_registry.BatchResolutionOutcome is BatchResolutionOutcome
+    assert entity_registry.BatchResolutionReport is BatchResolutionReport
+
+
+def test_batch_resolve_normalizes_supported_inputs_and_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def resolver(
+        raw_mention_text: str,
+        context: object = None,
+    ) -> MentionResolutionResult:
+        assert isinstance(context, dict)
+        calls.append((raw_mention_text, context))
+        return resolved_result(raw_mention_text)
+
+    monkeypatch.setattr(batch_module, "resolve_mention", resolver)
+    reference = make_reference(
+        "ref-entity",
+        "EntityRef Co",
+        {"source": "entity-reference"},
+    )
+
+    results = batch_resolve(
+        [
+            reference,
+            {
+                "reference_id": "ref-dict",
+                "raw_mention_text": "Dict Co",
+                "source_context": {"document_id": "doc-1", "offset": 9},
+            },
+            "Bare Co",
+        ]
+    )
+
+    assert [result.raw_mention_text for result in results] == [
+        "EntityRef Co",
+        "Dict Co",
+        "Bare Co",
+    ]
+    assert calls == [
+        ("EntityRef Co", {"source": "entity-reference"}),
+        ("Dict Co", {"document_id": "doc-1", "offset": 9}),
+        ("Bare Co", {}),
+    ]
+
+
+def test_collect_unresolved_references_filters_sorts_and_limits() -> None:
+    repository = InMemoryReferenceRepository()
+    newer = make_reference(
+        "ref-newer",
+        "Newer",
+        created_at=datetime(2026, 4, 16, tzinfo=UTC),
+    )
+    older = make_reference(
+        "ref-older",
+        "Older",
+        created_at=datetime(2026, 4, 15, tzinfo=UTC),
+    )
+    resolved = make_reference(
+        "ref-resolved",
+        "Resolved",
+        resolved_entity_id="ENT_STOCK_600519.SH",
+    )
+
+    repository.save(newer)
+    repository.save(resolved)
+    repository.save(older)
+
+    assert collect_unresolved_references(repository) == [older, newer]
+    assert collect_unresolved_references(repository, limit=1) == [older]
+
+
+def test_cluster_unresolved_references_groups_by_normalized_mention_and_candidates() -> None:
+    first = make_reference("ref-1", " CATL ", {"market": "A-share"})
+    second = make_reference("ref-2", "catl", {"market": "HK"})
+    third = make_reference("ref-3", "贵州茅台")
+    matcher = RecordingFuzzyMatcher(
+        {
+            " CATL ": [
+                make_candidate("ENT_STOCK_300750.SZ", score=0.90, alias_text="CATL"),
+                make_candidate("ENT_STOCK_03750.HK", score=0.91, alias_text="CATL"),
+            ],
+            "catl": [
+                make_candidate("ENT_STOCK_03750.HK", score=0.89, alias_text="CATL"),
+                make_candidate("ENT_STOCK_300750.SZ", score=0.88, alias_text="CATL"),
+            ],
+            "贵州茅台": [
+                make_candidate(
+                    "ENT_STOCK_600519.SH",
+                    score=0.97,
+                    alias_text="贵州茅台",
+                )
+            ],
+        }
+    )
+
+    groups = cluster_unresolved_references(
+        [third, first, second],
+        fuzzy_matcher=matcher,
+        limit=5,
+    )
+
+    catl_group = next(group for group in groups if group.normalized_mention == "catl")
+    assert catl_group.reference_ids == ["ref-1", "ref-2"]
+    assert catl_group.raw_mentions == [" CATL ", "catl"]
+    assert catl_group.candidate_entity_ids == [
+        "ENT_STOCK_03750.HK",
+        "ENT_STOCK_300750.SZ",
+    ]
+    assert catl_group.max_score == 0.91
+    assert len(groups) == 2
+    assert matcher.calls == [
+        ("贵州茅台", {"limit": 5, "context": {}}),
+        (" CATL ", {"limit": 5, "context": {"market": "A-share"}}),
+        ("catl", {"limit": 5, "context": {"market": "HK"}}),
+    ]
+
+
+def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id() -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def resolver(
+        raw_mention_text: str,
+        context: object = None,
+    ) -> MentionResolutionResult:
+        assert isinstance(context, dict)
+        calls.append((raw_mention_text, context))
+        return resolved_result(raw_mention_text)
+
+    job = BatchResolutionJob(job_id="job-dedupe", reference_ids=[], status="pending")
+    report = run_batch_resolution_job(
+        job,
+        [
+            {
+                "reference_id": "ref-1",
+                "raw_mention_text": "贵州茅台",
+                "source_context": {"document_id": "doc-1"},
+            },
+            {
+                "reference_id": "ref-1",
+                "raw_mention_text": "贵州茅台",
+                "source_context": {"document_id": "doc-1"},
+            },
+        ],
+        resolver=resolver,
+    )
+
+    assert calls == [("贵州茅台", {"document_id": "doc-1"})]
+    assert [outcome.result for outcome in report.outcomes] == [
+        resolved_result("贵州茅台"),
+        resolved_result("贵州茅台"),
+    ]
+    assert report.resolved_reference_ids == ["ref-1"]
+    assert report.job.reference_ids == ["ref-1"]
+    assert report.manual_review_reference_ids == []
+    assert report.job.status == "completed"
+    assert report.job.completed_at is not None
+
+
+def test_run_batch_resolution_job_keeps_completed_outcomes_when_one_item_fails() -> None:
+    def resolver(
+        raw_mention_text: str,
+        context: object = None,
+    ) -> MentionResolutionResult:
+        if raw_mention_text == "Broken":
+            raise RuntimeError("resolver exploded")
+        return resolved_result(raw_mention_text)
+
+    job = BatchResolutionJob(job_id="job-fail", reference_ids=[], status="pending")
+    report = run_batch_resolution_job(
+        job,
+        [
+            {"reference_id": "ref-ok", "raw_mention_text": "贵州茅台"},
+            {"reference_id": "ref-bad", "raw_mention_text": "Broken"},
+        ],
+        resolver=resolver,
+    )
+
+    assert report.job.status == "failed"
+    assert report.job.error_summary is not None
+    assert "ref-bad" in report.errors[0]
+    assert report.outcomes[0].final_status is FinalStatus.RESOLVED
+    assert report.outcomes[1].final_status is FinalStatus.UNRESOLVED
+    assert report.outcomes[1].result.resolution_method is ResolutionMethod.UNRESOLVED
+    assert report.resolved_reference_ids == ["ref-ok"]
+    assert report.unresolved_reference_ids == ["ref-bad"]
+    assert report.manual_review_reference_ids == ["ref-bad"]
+
+
+def test_public_batch_resolve_uses_configured_ner_fuzzy_reasoner_and_audit() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    fuzzy_matcher = RecordingFuzzyMatcher(
+        {
+            "宁德时代新能源": [
+                make_candidate(
+                    "ENT_STOCK_03750.HK",
+                    score=0.91,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+                make_candidate(
+                    "ENT_STOCK_300750.SZ",
+                    score=0.90,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+            ]
+        }
+    )
+    ner_extractor = StaticNERExtractor("宁德时代新能源")
+    reasoner_client = RecordingReasonerClient(
+        LLMDisambiguationResponse(
+            selected_entity_id="ENT_STOCK_03750.HK",
+            confidence=0.89,
+            rationale="HK market context",
+        )
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+        ner_extractor=ner_extractor,
+        reasoner_client=reasoner_client,
+    )
+
+    results = batch_resolve(
+        [
+            {
+                "reference_id": "ref-chain",
+                "raw_mention_text": "公告称宁德时代新能源获增持",
+                "source_context": {"market": "HK"},
+            }
+        ]
+    )
+
+    assert results[0].model_dump(mode="json") == {
+        "raw_mention_text": "公告称宁德时代新能源获增持",
+        "resolved_entity_id": "ENT_STOCK_03750.HK",
+        "resolution_method": "llm",
+        "resolution_confidence": 0.89,
+    }
+    assert ner_extractor.calls == ["公告称宁德时代新能源获增持"]
+    assert fuzzy_matcher.calls == [
+        ("宁德时代新能源", {"limit": 10, "context": {"market": "HK"}})
+    ]
+    assert len(reasoner_client.calls) == 1
+    assert list(reference_repo._references.values())[0].source_context == {"market": "HK"}
+
+
+def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+    source = make_reference("ref-ah", "宁德时代")
+    job = BatchResolutionJob(job_id="job-ah", reference_ids=[], status="pending")
+
+    report = run_batch_resolution_job(job, [source])
+
+    outcome = report.outcomes[0]
+    saved_reference = list(reference_repo._references.values())[0]
+    case = case_repo.find_by_reference(saved_reference.reference_id)[0]
+    assert outcome.result.resolved_entity_id is None
+    assert outcome.result.resolution_method is ResolutionMethod.UNRESOLVED
+    assert report.manual_review_reference_ids == ["ref-ah"]
+    assert report.unresolved_reference_ids == ["ref-ah"]
+    assert set(case.candidate_entity_ids) == {
+        "ENT_STOCK_300750.SZ",
+        "ENT_STOCK_03750.HK",
+    }
+
+
+def test_batch_report_and_job_round_trip_with_error_metadata() -> None:
+    job = BatchResolutionJob(
+        job_id="job-round-trip",
+        reference_ids=["ref-1"],
+        status="failed",
+        started_at=datetime(2026, 4, 15, tzinfo=UTC),
+        completed_at=datetime(2026, 4, 16, tzinfo=UTC),
+        error_summary="ref-1: RuntimeError: failure",
+    )
+    report = BatchResolutionReport(
+        job=job,
+        groups=[],
+        outcomes=[
+            BatchResolutionOutcome(
+                source_reference_id="ref-1",
+                result=unresolved_result("Unknown"),
+                final_status=FinalStatus.UNRESOLVED,
+                error="RuntimeError: failure",
+            )
+        ],
+        resolved_reference_ids=[],
+        unresolved_reference_ids=["ref-1"],
+        manual_review_reference_ids=["ref-1"],
+        errors=["ref-1: RuntimeError: failure"],
+    )
+
+    restored = BatchResolutionReport.model_validate(report.model_dump(mode="json"))
+
+    assert restored == report
+
+
+def test_batch_module_has_no_provider_sdk_imports() -> None:
+    for path in (
+        "src/entity_registry/batch.py",
+        "src/entity_registry/resolution.py",
+        "src/entity_registry/fuzzy.py",
+    ):
+        text = Path(path).read_text(encoding="utf-8")
+        for forbidden in ("openai", "anthropic", "google.generativeai"):
+            assert forbidden not in text
+
+
+def initialized_repositories() -> tuple[
+    InMemoryEntityRepository,
+    InMemoryAliasRepository,
+]:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    return entity_repo, alias_repo
+
+
+def make_reference(
+    reference_id: str,
+    raw_mention_text: str,
+    source_context: dict[str, object] | None = None,
+    *,
+    resolved_entity_id: str | None = None,
+    created_at: datetime | None = None,
+) -> EntityReference:
+    return EntityReference(
+        reference_id=reference_id,
+        raw_mention_text=raw_mention_text,
+        source_context={} if source_context is None else source_context,
+        resolved_entity_id=resolved_entity_id,
+        resolution_method=(
+            ResolutionMethod.DETERMINISTIC
+            if resolved_entity_id is not None
+            else ResolutionMethod.UNRESOLVED
+        ),
+        resolution_confidence=1.0 if resolved_entity_id is not None else None,
+        created_at=created_at or datetime(2026, 4, 15, tzinfo=UTC),
+    )
+
+
+def make_candidate(
+    entity_id: str,
+    *,
+    score: float,
+    alias_text: str,
+) -> FuzzyCandidate:
+    return FuzzyCandidate(
+        canonical_entity_id=entity_id,
+        alias_text=alias_text,
+        alias_type=AliasType.SHORT_NAME,
+        score=score,
+        source="unit-test",
+        blocking_key=alias_text[:2],
+    )
+
+
+def resolved_result(raw_mention_text: str) -> MentionResolutionResult:
+    return MentionResolutionResult(
+        raw_mention_text=raw_mention_text,
+        resolved_entity_id="ENT_STOCK_600519.SH",
+        resolution_method=ResolutionMethod.DETERMINISTIC,
+        resolution_confidence=1.0,
+    )
+
+
+def unresolved_result(raw_mention_text: str) -> MentionResolutionResult:
+    return MentionResolutionResult(
+        raw_mention_text=raw_mention_text,
+        resolved_entity_id=None,
+        resolution_method=ResolutionMethod.UNRESOLVED,
+        resolution_confidence=None,
+    )
+
+
+class RecordingFuzzyMatcher:
+    auto_resolve_score = 0.96
+
+    def __init__(self, candidates_by_text: dict[str, list[FuzzyCandidate]]) -> None:
+        self._candidates_by_text = candidates_by_text
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def generate_candidates(
+        self,
+        raw_mention_text: str,
+        *,
+        context: object = None,
+        limit: int = 10,
+    ) -> list[FuzzyCandidate]:
+        self.calls.append(
+            (
+                raw_mention_text,
+                {
+                    "limit": limit,
+                    "context": context if isinstance(context, dict) else {},
+                },
+            )
+        )
+        return self._candidates_by_text.get(raw_mention_text, [])[:limit]
+
+
+class StaticNERExtractor:
+    def __init__(self, mention_text: str) -> None:
+        self._mention_text = mention_text
+        self.calls: list[str] = []
+
+    def extract_mentions(
+        self,
+        text: str,
+        *,
+        context: object = None,
+    ) -> list[ExtractedMention]:
+        self.calls.append(text)
+        return [ExtractedMention(mention_text=self._mention_text)]
+
+
+class RecordingReasonerClient:
+    def __init__(self, response: LLMDisambiguationResponse) -> None:
+        self._response = response
+        self.calls: list[LLMDisambiguationRequest] = []
+
+    def disambiguate(
+        self,
+        request: LLMDisambiguationRequest,
+    ) -> LLMDisambiguationResponse:
+        self.calls.append(request)
+        return self._response


### PR DESCRIPTION
Closes #9

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/resolution_types.py`, `tests/test_repository_hygiene.py`


---
## 1. 背景与目标

项目文档 §11.4 和 §16.1 要求提供 `batch_resolve(references)`，用于批量处理未解析引用、生成候选组并把无法自动裁决的项分流到人工复核。当前代码已经有 `src/entity_registry/resolution.py` 的 `resolve_mention()` / `resolve_mention_with_repositories()`、`src/entity_registry.references.EntityReference` / `ResolutionCase`、`src/entity_registry.storage.ReferenceRepository.find_unresolved()`，以及 `src/entity_registry.resolution_types.BatchResolutionJob` 的最小模型。本 issue 的目标是在不重写单次解析链的前提下，新建批量编排层，让 batch 复用 #8 的完整 Deterministic -> NER -> Splink fuzzy -> reasoner-runtime -> audit 路径，并产出可由 #10 消费的 manual-review 分流结果。

## 2. 所属模块

主写入路径：
- `src/entity_registry/batch.py`（新建，批量任务、分组、运行报告和公共 `batch_resolve` API）
- `src/entity_registry/__init__.py`（导出 batch 公共 API）
- `tests/test_batch.py`（新建）

相邻可写路径：
- `src/entity_registry/storage.py`（仅在需要持久化 `BatchResolutionJob` 生命周期时添加 `BatchResolutionJobRepository` / `InMemoryBatchResolutionJobRepository`，沿用现有 repository protocol 风格）
- `src/entity_registry/resolution_types.py`（仅允许小幅扩展已有 `BatchResolutionJob` 的字段或校验，不新增并行 candidate 状态）

只读集成路径：
- `src/entity_registry/resolution.py`
- `src/entity_registry/fuzzy.py`
- `src/entity_registry/ner.py`
- `src/entity_registry/llm_client.py`
- `src/entity_registry/references.py`
- `src/entity_registry/core.py`

## 3. 实现范围

- 新建 `src/entity_registry/batch.py`，从 `entity_registry.references` 复用 `EntityReference`，从 `entity_registry.resolution_types` 复用 `BatchResolutionJob`、`MentionResolutionResult`、`ResolutionContext`，从 `entity_registry.core` 复用 `FinalStatus` / `ResolutionMethod`。
- 定义批量输入归一化：支持 `EntityReference`、`dict[str, object]` 和裸 `str` mention，统一转为 `BatchReferenceInput` 或等价内部模型；dict 输入必须保留 `raw_mention_text` / `source_context`，不能丢掉原始引用上下文。
- 实现 unresolved 收集函数，基于现有 `ReferenceRepository.find_unresolved() -> list[EntityReference]` 拉取待回补引用，并支持 `limit` 与稳定排序，避免一次 job 无界读取。
- 实现 batch 分组层：使用 #31 补齐后的 `FuzzyMatcher.generate_candidates(raw_mention_text, context=..., limit=...) -> list[FuzzyCandidate]` 作为候选来源，按 normalized mention、blocking key、候选 entity id 集合形成 