### PR TITLE
feat(#37): [milestone-3 review] P0: Manual review decisions lose original reference timestamp

### DIFF
--- a/src/entity_registry/review.py
+++ b/src/entity_registry/review.py
@@ -405,7 +405,12 @@ def _reference_for_decision(
 
 
 def _reference_created_at_for_item(item: UnresolvedQueueItem) -> datetime:
-    return item.reference_created_at or item.created_at
+    if item.reference_created_at is None:
+        raise ReviewStateError(
+            "review queue item is missing original reference_created_at: "
+            f"{item.queue_item_id}"
+        )
+    return item.reference_created_at
 
 
 def _manual_confidence(decision: ManualReviewDecision) -> float:

--- a/src/entity_registry/review.py
+++ b/src/entity_registry/review.py
@@ -67,6 +67,7 @@ class UnresolvedQueueItem(BaseModel):
     reference_id: str
     raw_mention_text: str
     source_context: dict[str, object]
+    reference_created_at: datetime | None = None
     candidate_entity_ids: list[str]
     status: str
     claimed_by: str | None = None
@@ -193,6 +194,12 @@ def enqueue_unresolved_reference(
     _require_explicit_unresolved(reference)
     existing = review_repo.find_by_reference(reference.reference_id)
     if existing is not None:
+        if existing.reference_created_at is None:
+            updated = existing.model_copy(
+                update={"reference_created_at": reference.created_at}
+            )
+            review_repo.save(updated)
+            return review_repo.find_by_reference(reference.reference_id) or updated
         return existing
 
     latest_case = _latest_case_for_reference(reference.reference_id, case_repo)
@@ -202,6 +209,7 @@ def enqueue_unresolved_reference(
         reference_id=reference.reference_id,
         raw_mention_text=reference.raw_mention_text,
         source_context=dict(reference.source_context),
+        reference_created_at=reference.created_at,
         candidate_entity_ids=list(latest_case.candidate_entity_ids),
         status=REVIEW_STATUS_PENDING,
         claimed_by=None,
@@ -392,7 +400,12 @@ def _reference_for_decision(
             if selected_entity_id is None
             else _manual_confidence(decision)
         ),
+        created_at=_reference_created_at_for_item(item),
     )
+
+
+def _reference_created_at_for_item(item: UnresolvedQueueItem) -> datetime:
+    return item.reference_created_at or item.created_at
 
 
 def _manual_confidence(decision: ManualReviewDecision) -> float:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -48,6 +48,8 @@ from entity_registry.storage import (
     InMemoryReviewRepository,
 )
 
+REFERENCE_CREATED_AT = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)
+
 
 def test_review_public_exports_and_signatures() -> None:
     assert entity_registry.UnresolvedQueueItem is UnresolvedQueueItem
@@ -286,6 +288,36 @@ def test_reject_decision_writes_unresolved_audit_and_marks_rejected() -> None:
     assert saved_case.selected_entity_id is None
     assert updated_item.status == REVIEW_STATUS_REJECTED
     assert updated_item.decided_at is not None
+
+
+def test_manual_review_decision_rejects_missing_reference_created_at() -> None:
+    review_repo, item = queued_item()
+    missing_timestamp_item = item.model_copy(
+        update={"reference_created_at": None}
+    )
+    review_repo.save(missing_timestamp_item)
+    case_repo = InMemoryResolutionCaseRepository()
+    audit_writer = InMemoryResolutionAuditReferenceRepository(case_repo)
+
+    with pytest.raises(ReviewStateError, match="reference_created_at"):
+        submit_manual_review_decision(
+            item.queue_item_id,
+            ManualReviewDecision(
+                selected_entity_id=None,
+                confidence=None,
+                rationale="cannot audit without original capture timestamp",
+            ),
+            review_repo=review_repo,
+            entity_repo=InMemoryEntityRepository(),
+            alias_repo=InMemoryAliasRepository(),
+            audit_writer=audit_writer,
+        )
+
+    unchanged = review_repo.get(item.queue_item_id)
+    assert unchanged.status == REVIEW_STATUS_PENDING
+    assert unchanged.reference_created_at is None
+    assert audit_writer.get(item.reference_id) is None
+    assert case_repo.find_by_reference(item.reference_id) == []
 
 
 def test_promote_decision_writes_manual_resolution_for_existing_entity() -> None:
@@ -760,6 +792,7 @@ def queued_item(
         reference_id="ref-review",
         raw_mention_text=raw_mention_text,
         source_context={"document_id": "doc-review"},
+        reference_created_at=REFERENCE_CREATED_AT,
         candidate_entity_ids=(
             ["ENT_STOCK_300750.SZ"]
             if candidate_entity_ids is None
@@ -784,6 +817,7 @@ def queued_item_with_repository(
         reference_id="ref-review",
         raw_mention_text=raw_mention_text,
         source_context={"document_id": "doc-review"},
+        reference_created_at=REFERENCE_CREATED_AT,
         candidate_entity_ids=(
             ["ENT_STOCK_300750.SZ"]
             if candidate_entity_ids is None

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -675,6 +675,68 @@ def test_get_resolution_audit_payload_uses_latest_case_and_includes_queue_item()
     assert payload.queue_item == item
 
 
+def test_manual_review_decision_preserves_original_reference_created_at() -> None:
+    original_created_at = datetime(2026, 4, 1, 8, 30, tzinfo=UTC)
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    entity_repo = InMemoryEntityRepository()
+    entity_repo.save(make_entity("ENT_STOCK_300750.SZ"))
+    reference = make_reference(
+        "ref-original-created-at",
+        "宁德时代新能源",
+        created_at=original_created_at,
+    )
+    reference_repo.save(reference)
+    case_repo.save(
+        make_case(
+            "case-original-created-at",
+            "ref-original-created-at",
+            ["ENT_STOCK_300750.SZ"],
+        )
+    )
+
+    (item,) = enqueue_batch_manual_review(
+        make_report(["ref-original-created-at"]),
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    claimed = claim_review_item(
+        item.queue_item_id,
+        "reviewer-a",
+        review_repo=review_repo,
+    )
+    decision_payload = submit_manual_review_decision(
+        item.queue_item_id,
+        ManualReviewDecision(
+            selected_entity_id="ENT_STOCK_300750.SZ",
+            confidence=0.93,
+            rationale="reviewer selected captured mention",
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=InMemoryAliasRepository(),
+        audit_writer=reference_repo,
+    )
+    audit_payload = get_resolution_audit_payload(
+        "ref-original-created-at",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+
+    assert item.reference_created_at == original_created_at
+    assert claimed.reference_created_at == original_created_at
+    assert decision_payload.entity_reference.created_at == original_created_at
+    assert reference_repo.get("ref-original-created-at").created_at == (
+        original_created_at
+    )
+    assert audit_payload.entity_reference.created_at == original_created_at
+    assert audit_payload.queue_item.reference_created_at == original_created_at
+    assert audit_payload.queue_item.decided_at is not None
+
+
 def test_review_module_has_no_provider_sdk_or_reasoner_runtime_imports() -> None:
     text = Path("src/entity_registry/review.py").read_text(encoding="utf-8")
 
@@ -740,6 +802,7 @@ def make_reference(
     raw_mention_text: str,
     *,
     resolved_entity_id: str | None = None,
+    created_at: datetime | None = None,
 ) -> EntityReference:
     return EntityReference(
         reference_id=reference_id,
@@ -752,7 +815,7 @@ def make_reference(
             else ResolutionMethod.DETERMINISTIC
         ),
         resolution_confidence=None if resolved_entity_id is None else 1.0,
-        created_at=datetime(2026, 4, 15, tzinfo=UTC),
+        created_at=created_at or datetime(2026, 4, 15, tzinfo=UTC),
     )
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 
 from entity_registry.core import (
@@ -31,6 +33,8 @@ from entity_registry.storage import (
     ReviewRepository,
     ResolutionCaseRepository,
 )
+
+REFERENCE_CREATED_AT = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)
 
 
 def make_entity(entity_id: str = "ENT_STOCK_300750.SZ") -> CanonicalEntity:
@@ -561,6 +565,7 @@ def make_queue_item(queue_item_id: str, reference_id: str) -> UnresolvedQueueIte
         reference_id=reference_id,
         raw_mention_text="Unknown Corp",
         source_context={"source": "unit-test"},
+        reference_created_at=REFERENCE_CREATED_AT,
         candidate_entity_ids=[],
         status=REVIEW_STATUS_PENDING,
     )


### PR DESCRIPTION
Closes #37

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/batch.py`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/review.py`, `src/entity_registry/storage.py`, `tests/test_repository_hygiene.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
Batch backfill deliberately preserves an existing unresolved EntityReference.created_at when updating a reference, but manual review decision writes create a fresh EntityReference without carrying over the original reference's created_at. This makes the audit chain inconsistent across automatic backfill and manual adjudication: the same reference_id can appear to have been created at decision time rather than at original mention capture time. The audit payload then cannot reliably distinguish capture time from adjudication time.

## 实现范围
- 修改文件: `src/entity_registry/review.py`
- Pass the original EntityReference into submit_manual_review_decision or require ReviewRepository/queue items to retain the original reference created_at, then construct the manual-review EntityReference with that timestamp. Add an integration test that an unresolved reference created_at survives enqueue, claim, manual decision, and audit payload retrieval.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
