### PR TITLE
feat(#36): [milestone-3 review] P0: Public batch API drops manual-review handoff data

### DIFF
--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -23,6 +23,7 @@ from entity_registry.batch import (
     BatchResolutionOutcome,
     BatchResolutionReport,
     batch_resolve,
+    batch_resolve_with_report,
 )
 from entity_registry.fuzzy import (
     FuzzyCandidate,
@@ -165,6 +166,7 @@ __all__ = [
     "SplinkFuzzyMatcher",
     "UnresolvedQueueItem",
     "batch_resolve",
+    "batch_resolve_with_report",
     "build_disambiguation_request",
     "claim_review_item",
     "configure_default_in_memory_audit_repositories",

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -356,7 +356,36 @@ def _ensure_source_reference_ids(
                 },
             )
         )
+    _validate_effective_reference_ids(normalized)
     return normalized
+
+
+def _validate_effective_reference_ids(inputs: Sequence[BatchReferenceInput]) -> None:
+    seen_by_reference_id: dict[str, BatchReferenceInput] = {}
+    for item in inputs:
+        if item.source_reference_id is None:
+            continue
+
+        existing = seen_by_reference_id.get(item.source_reference_id)
+        if existing is None:
+            seen_by_reference_id[item.source_reference_id] = item
+            continue
+
+        if not _same_reference_input_identity(existing, item):
+            raise ValueError(
+                "duplicate source_reference_id maps to different batch inputs: "
+                f"{item.source_reference_id}"
+            )
+
+
+def _same_reference_input_identity(
+    first: BatchReferenceInput,
+    second: BatchReferenceInput,
+) -> bool:
+    return (
+        first.raw_mention_text == second.raw_mention_text
+        and first.source_context == second.source_context
+    )
 
 
 def _enqueue_manual_review_items(

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -63,6 +63,15 @@ class BatchReferenceInput(BaseModel):
             raise ValueError("raw_mention_text must be a non-empty string")
         return value
 
+    @field_validator("source_reference_id")
+    @classmethod
+    def validate_source_reference_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("source_reference_id must be a non-empty string")
+        return value
+
 
 class BatchCandidateGroup(BaseModel):
     """Candidate group shared by one or more unresolved references."""

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -28,10 +28,16 @@ from entity_registry.resolution_types import (
     MentionResolutionResult,
     ResolutionContext,
 )
-from entity_registry.storage import ReferenceRepository
+from entity_registry.storage import ReferenceRepository, ReviewRepository
 
 
 _DEFAULT_RESOLVE_MENTION = resolve_mention
+_RESOLUTION_REPOSITORIES_REQUIRED_MESSAGE = (
+    "resolution audit repositories are not configured; "
+    "call configure_default_repositories(..., reference_repo=..., "
+    "case_repo=...) before using public resolution APIs, or use "
+    "configure_default_in_memory_audit_repositories() for tests/local workflows"
+)
 
 Resolver = Callable[
     ...,
@@ -238,24 +244,112 @@ def run_batch_resolution_job(
 def batch_resolve(
     references: Sequence[EntityReference | dict[str, object] | str],
 ) -> list[MentionResolutionResult]:
-    """Resolve a batch of mentions and return the stable public result shape."""
+    """Resolve a batch of mentions and return the stable public result shape.
+
+    Use batch_resolve_with_report(..., review_repo=...) when callers need the
+    report fields required for manual-review handoff.
+    """
 
     normalized_inputs = [_coerce_reference_input(reference) for reference in references]
-    job = BatchResolutionJob(
+    job = _new_batch_job(normalized_inputs)
+    report = run_batch_resolution_job(job, normalized_inputs)
+    _raise_for_report_errors(report)
+    return [outcome.result for outcome in report.outcomes]
+
+
+def batch_resolve_with_report(
+    references: Sequence[EntityReference | dict[str, object] | str],
+    *,
+    review_repo: ReviewRepository | None = None,
+) -> BatchResolutionReport:
+    """Resolve a batch and return the manual-review handoff report.
+
+    Anonymous dict/string inputs are assigned durable reference IDs before
+    resolution, so unresolved outputs appear in manual_review_reference_ids and
+    can be fetched from the configured reference repository.
+
+    When review_repo is provided, unresolved outputs are enqueued before this
+    function returns. Without review_repo, callers that need handoff must pass
+    the returned report to enqueue_batch_manual_review(report, ...), using the
+    same configured reference and case repositories.
+    """
+
+    repository_context = _get_default_resolution_repository_context()
+    normalized_inputs = _ensure_source_reference_ids(
+        [_coerce_reference_input(reference) for reference in references]
+    )
+    job = _new_batch_job(normalized_inputs)
+    report = run_batch_resolution_job(
+        job,
+        normalized_inputs,
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+    )
+    _raise_for_report_errors(report)
+
+    if review_repo is not None:
+        from entity_registry.review import enqueue_batch_manual_review
+
+        enqueue_batch_manual_review(
+            report,
+            reference_repo=repository_context.reference_repo,
+            case_repo=repository_context.case_repo,
+            review_repo=review_repo,
+        )
+
+    return report
+
+
+def _new_batch_job(inputs: Sequence[BatchReferenceInput]) -> BatchResolutionJob:
+    return BatchResolutionJob(
         job_id=_new_job_id(),
         reference_ids=_unique_ids([
             item.source_reference_id
-            for item in normalized_inputs
+            for item in inputs
             if item.source_reference_id is not None
         ]),
         status="pending",
     )
-    report = run_batch_resolution_job(job, normalized_inputs)
+
+
+def _ensure_source_reference_ids(
+    inputs: Sequence[BatchReferenceInput],
+) -> list[BatchReferenceInput]:
+    normalized: list[BatchReferenceInput] = []
+    for item in inputs:
+        if item.source_reference_id is not None:
+            normalized.append(item)
+            continue
+
+        normalized.append(
+            item.model_copy(
+                update={"source_reference_id": _new_batch_reference_id()},
+            )
+        )
+    return normalized
+
+
+def _get_default_resolution_repository_context():
+    from entity_registry.init import (
+        RepositoryNotConfiguredError,
+        _get_default_repository_context,
+    )
+
+    repository_context = _get_default_repository_context()
+    if (
+        repository_context.reference_repo is None
+        or repository_context.case_repo is None
+    ):
+        raise RepositoryNotConfiguredError(
+            _RESOLUTION_REPOSITORIES_REQUIRED_MESSAGE,
+        )
+    return repository_context
+
+
+def _raise_for_report_errors(report: BatchResolutionReport) -> None:
     if report.errors:
         raise RuntimeError(
             "batch resolution failed: " + "; ".join(report.errors),
         )
-    return [outcome.result for outcome in report.outcomes]
 
 
 def _coerce_reference_input(
@@ -351,23 +445,7 @@ def _resolve_mention_for_batch(
     if existing_reference_id is None:
         return resolve_mention(raw_mention_text, context)
 
-    from entity_registry.init import (
-        RepositoryNotConfiguredError,
-        _get_default_repository_context,
-    )
-
-    repository_context = _get_default_repository_context()
-    if (
-        repository_context.reference_repo is None
-        or repository_context.case_repo is None
-    ):
-        raise RepositoryNotConfiguredError(
-            "resolution audit repositories are not configured; "
-            "call configure_default_repositories(..., reference_repo=..., "
-            "case_repo=...) before using public resolution APIs, or use "
-            "configure_default_in_memory_audit_repositories() for tests/local workflows",
-        )
-
+    repository_context = _get_default_resolution_repository_context()
     return resolve_mention_with_repositories(
         raw_mention_text,
         context,
@@ -584,6 +662,10 @@ def _new_job_id() -> str:
     return f"BATCH_{uuid4().hex}"
 
 
+def _new_batch_reference_id() -> str:
+    return f"REF_{uuid4().hex}"
+
+
 def _utcnow() -> datetime:
     return datetime.now(UTC)
 
@@ -594,6 +676,7 @@ __all__ = [
     "BatchResolutionOutcome",
     "BatchResolutionReport",
     "batch_resolve",
+    "batch_resolve_with_report",
     "cluster_unresolved_references",
     "collect_unresolved_references",
     "run_batch_resolution_job",

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -28,7 +28,11 @@ from entity_registry.resolution_types import (
     MentionResolutionResult,
     ResolutionContext,
 )
-from entity_registry.storage import ReferenceRepository, ReviewRepository
+from entity_registry.storage import (
+    ReferenceRepository,
+    ResolutionCaseRepository,
+    ReviewRepository,
+)
 
 
 _DEFAULT_RESOLVE_MENTION = resolve_mention
@@ -261,22 +265,25 @@ def batch_resolve_with_report(
     references: Sequence[EntityReference | dict[str, object] | str],
     *,
     review_repo: ReviewRepository | None = None,
+    reference_ids: Sequence[str | None] | None = None,
 ) -> BatchResolutionReport:
     """Resolve a batch and return the manual-review handoff report.
 
     Anonymous dict/string inputs are assigned durable reference IDs before
-    resolution, so unresolved outputs appear in manual_review_reference_ids and
-    can be fetched from the configured reference repository.
+    resolution. Callers can pass reference_ids to make those assignments stable
+    across retry attempts.
 
     When review_repo is provided, unresolved outputs are enqueued before this
-    function returns. Without review_repo, callers that need handoff must pass
-    the returned report to enqueue_batch_manual_review(report, ...), using the
-    same configured reference and case repositories.
+    function returns. If enqueue fails after audit persistence, the returned
+    report records the enqueue error so callers can retry
+    enqueue_batch_manual_review(report, ...) with the same configured reference
+    and case repositories.
     """
 
     repository_context = _get_default_resolution_repository_context()
     normalized_inputs = _ensure_source_reference_ids(
-        [_coerce_reference_input(reference) for reference in references]
+        [_coerce_reference_input(reference) for reference in references],
+        reference_ids=reference_ids,
     )
     job = _new_batch_job(normalized_inputs)
     report = run_batch_resolution_job(
@@ -287,9 +294,7 @@ def batch_resolve_with_report(
     _raise_for_report_errors(report)
 
     if review_repo is not None:
-        from entity_registry.review import enqueue_batch_manual_review
-
-        enqueue_batch_manual_review(
+        _enqueue_manual_review_items(
             report,
             reference_repo=repository_context.reference_repo,
             case_repo=repository_context.case_repo,
@@ -313,19 +318,67 @@ def _new_batch_job(inputs: Sequence[BatchReferenceInput]) -> BatchResolutionJob:
 
 def _ensure_source_reference_ids(
     inputs: Sequence[BatchReferenceInput],
+    *,
+    reference_ids: Sequence[str | None] | None = None,
 ) -> list[BatchReferenceInput]:
+    if reference_ids is not None and len(reference_ids) != len(inputs):
+        raise ValueError("reference_ids length must match references length")
+
     normalized: list[BatchReferenceInput] = []
-    for item in inputs:
+    for index, item in enumerate(inputs):
+        supplied_reference_id = (
+            None if reference_ids is None else reference_ids[index]
+        )
+        if supplied_reference_id is not None:
+            if (
+                not isinstance(supplied_reference_id, str)
+                or not supplied_reference_id.strip()
+            ):
+                raise ValueError("reference_ids must contain non-empty strings")
+
         if item.source_reference_id is not None:
+            if (
+                supplied_reference_id is not None
+                and supplied_reference_id != item.source_reference_id
+            ):
+                raise ValueError(
+                    "reference_ids cannot override an input source_reference_id"
+                )
             normalized.append(item)
             continue
 
         normalized.append(
             item.model_copy(
-                update={"source_reference_id": _new_batch_reference_id()},
+                update={
+                    "source_reference_id": (
+                        supplied_reference_id or _new_batch_reference_id()
+                    ),
+                },
             )
         )
     return normalized
+
+
+def _enqueue_manual_review_items(
+    report: BatchResolutionReport,
+    *,
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+    review_repo: ReviewRepository,
+) -> None:
+    from entity_registry.review import enqueue_batch_manual_review
+
+    try:
+        enqueue_batch_manual_review(
+            report,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            review_repo=review_repo,
+        )
+    except Exception as exc:
+        error = f"manual review enqueue failed: {type(exc).__name__}: {exc}"
+        report.errors.append(error)
+        _mark_job_failed(report.job, error)
 
 
 def _get_default_resolution_repository_context():

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -380,21 +380,10 @@ def _validate_effective_reference_ids(inputs: Sequence[BatchReferenceInput]) -> 
             seen_by_reference_id[item.source_reference_id] = item
             continue
 
-        if not _same_reference_input_identity(existing, item):
-            raise ValueError(
-                "duplicate source_reference_id maps to different batch inputs: "
-                f"{item.source_reference_id}"
-            )
-
-
-def _same_reference_input_identity(
-    first: BatchReferenceInput,
-    second: BatchReferenceInput,
-) -> bool:
-    return (
-        first.raw_mention_text == second.raw_mention_text
-        and first.source_context == second.source_context
-    )
+        raise ValueError(
+            "duplicate source_reference_id in batch inputs: "
+            f"{item.source_reference_id}"
+        )
 
 
 def _enqueue_manual_review_items(

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -13,6 +13,7 @@ from entity_registry.batch import (
     BatchResolutionOutcome,
     BatchResolutionReport,
     batch_resolve,
+    batch_resolve_with_report,
     cluster_unresolved_references,
     collect_unresolved_references,
     run_batch_resolution_job,
@@ -34,6 +35,7 @@ from entity_registry.storage import (
     InMemoryAliasRepository,
     InMemoryEntityRepository,
     InMemoryReferenceRepository,
+    InMemoryReviewRepository,
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
 )
@@ -51,9 +53,17 @@ def reset_public_repositories() -> Iterator[None]:
 
 def test_batch_resolve_public_signature_and_exports() -> None:
     signature = inspect.signature(batch_resolve)
+    report_signature = inspect.signature(batch_resolve_with_report)
 
     assert list(signature.parameters) == ["references"]
+    assert list(report_signature.parameters) == ["references", "review_repo"]
+    assert (
+        report_signature.parameters["review_repo"].kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert report_signature.parameters["review_repo"].default is None
     assert entity_registry.batch_resolve is batch_resolve
+    assert entity_registry.batch_resolve_with_report is batch_resolve_with_report
     assert entity_registry.BatchReferenceInput is BatchReferenceInput
     assert entity_registry.BatchCandidateGroup is BatchCandidateGroup
     assert entity_registry.BatchResolutionOutcome is BatchResolutionOutcome
@@ -445,6 +455,139 @@ def test_public_batch_resolve_uses_configured_ner_fuzzy_reasoner_and_audit() -> 
     ]
     assert len(reasoner_client.calls) == 1
     assert list(reference_repo._references.values())[0].source_context == {"market": "HK"}
+
+
+def test_batch_resolve_with_report_enqueues_review_items_and_supports_decisions() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    fuzzy_matcher = RecordingFuzzyMatcher(
+        {
+            "宁德时代新能源": [
+                make_candidate(
+                    "ENT_STOCK_300750.SZ",
+                    score=0.91,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+                make_candidate(
+                    "ENT_STOCK_03750.HK",
+                    score=0.90,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+            ]
+        }
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+    )
+
+    report = batch_resolve_with_report(
+        [
+            {
+                "raw_mention_text": "宁德时代",
+                "source_context": {"document_id": "doc-review", "path": "reject"},
+            },
+            {
+                "raw_mention_text": "宁德时代新能源",
+                "source_context": {"document_id": "doc-review", "path": "promote"},
+            },
+        ],
+        review_repo=review_repo,
+    )
+
+    assert len(report.manual_review_reference_ids) == 2
+    assert set(report.unresolved_reference_ids) == set(
+        report.manual_review_reference_ids
+    )
+    grouped_reference_ids = {
+        reference_id
+        for group in report.groups
+        for reference_id in group.reference_ids
+    }
+    assert set(report.manual_review_reference_ids) <= grouped_reference_ids
+
+    reject_reference_id, promote_reference_id = report.manual_review_reference_ids
+    reject_item = review_repo.find_by_reference(reject_reference_id)
+    promote_item = review_repo.find_by_reference(promote_reference_id)
+    assert reject_item is not None
+    assert promote_item is not None
+    assert reference_repo.get(reject_reference_id).raw_mention_text == "宁德时代"
+    assert reference_repo.get(promote_reference_id).raw_mention_text == (
+        "宁德时代新能源"
+    )
+
+    entity_registry.claim_review_item(
+        reject_item.queue_item_id,
+        "reviewer-a",
+        review_repo=review_repo,
+    )
+    rejected_payload = entity_registry.submit_manual_review_decision(
+        reject_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id=None,
+            confidence=None,
+            rationale="not enough evidence to map to a listing",
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+
+    entity_registry.claim_review_item(
+        promote_item.queue_item_id,
+        "reviewer-b",
+        review_repo=review_repo,
+    )
+    promoted_payload = entity_registry.submit_manual_review_decision(
+        promote_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id="ENT_STOCK_300750.SZ",
+            confidence=0.93,
+            rationale="reviewer selected the A-share listing",
+            promote_alias=True,
+            alias_type=AliasType.SHORT_NAME,
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+
+    rejected_audit = entity_registry.get_resolution_audit_payload(
+        reject_reference_id,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_audit = entity_registry.get_resolution_audit_payload(
+        promote_reference_id,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    manual_aliases = [
+        alias
+        for alias in alias_repo.find_by_entity("ENT_STOCK_300750.SZ")
+        if alias.alias_text == "宁德时代新能源"
+        and alias.source == "manual_review"
+    ]
+
+    assert rejected_payload.unresolved is True
+    assert rejected_audit.entity_reference.resolution_method is (
+        ResolutionMethod.UNRESOLVED
+    )
+    assert rejected_audit.queue_item.status == "rejected"
+    assert promoted_payload.unresolved is False
+    assert promoted_audit.entity_reference.resolved_entity_id == "ENT_STOCK_300750.SZ"
+    assert promoted_audit.entity_reference.resolution_method is ResolutionMethod.MANUAL
+    assert promoted_audit.queue_item.status == "promoted"
+    assert len(manual_aliases) == 1
 
 
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -699,6 +699,39 @@ def test_batch_resolve_with_report_rejects_duplicate_reference_ids_before_writes
     assert review_repo.list_by_status("pending") == []
 
 
+def test_batch_resolve_with_report_rejects_embedded_invalid_reference_ids_before_writes() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(ValueError, match="source_reference_id.*non-empty"):
+        batch_resolve_with_report(
+            [
+                {
+                    "raw_mention_text": "Unlisted Before Malformed Ref",
+                    "source_context": {"offset": 1},
+                },
+                {
+                    "reference_id": "   ",
+                    "raw_mention_text": "Malformed Embedded Ref",
+                    "source_context": {"offset": 2},
+                },
+            ],
+            review_repo=review_repo,
+        )
+
+    assert reference_repo._references == {}
+    assert case_repo._cases == {}
+    assert review_repo.list_by_status("pending") == []
+
+
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -666,6 +666,39 @@ def test_batch_resolve_with_report_returns_report_when_review_enqueue_fails() ->
     assert set(reference_repo._references) == set(reference_ids)
 
 
+def test_batch_resolve_with_report_rejects_duplicate_reference_ids_before_writes() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        batch_resolve_with_report(
+            [
+                {
+                    "raw_mention_text": "Duplicate Ref A",
+                    "source_context": {"offset": 1},
+                },
+                {
+                    "raw_mention_text": "Duplicate Ref B",
+                    "source_context": {"offset": 2},
+                },
+            ],
+            review_repo=review_repo,
+            reference_ids=["ref-duplicate", "ref-duplicate"],
+        )
+
+    assert reference_repo._references == {}
+    assert case_repo._cases == {}
+    assert review_repo.list_by_status("pending") == []
+
+
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -699,6 +699,39 @@ def test_batch_resolve_with_report_rejects_duplicate_reference_ids_before_writes
     assert review_repo.list_by_status("pending") == []
 
 
+def test_batch_resolve_with_report_rejects_duplicate_identical_reference_ids_before_writes() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        batch_resolve_with_report(
+            [
+                {
+                    "raw_mention_text": "Duplicate Identical Ref",
+                    "source_context": {"offset": 1},
+                },
+                {
+                    "raw_mention_text": "Duplicate Identical Ref",
+                    "source_context": {"offset": 1},
+                },
+            ],
+            review_repo=review_repo,
+            reference_ids=["ref-duplicate-identical", "ref-duplicate-identical"],
+        )
+
+    assert reference_repo._references == {}
+    assert case_repo._cases == {}
+    assert review_repo.list_by_status("pending") == []
+
+
 def test_batch_resolve_with_report_rejects_embedded_invalid_reference_ids_before_writes() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -56,12 +56,21 @@ def test_batch_resolve_public_signature_and_exports() -> None:
     report_signature = inspect.signature(batch_resolve_with_report)
 
     assert list(signature.parameters) == ["references"]
-    assert list(report_signature.parameters) == ["references", "review_repo"]
+    assert list(report_signature.parameters) == [
+        "references",
+        "review_repo",
+        "reference_ids",
+    ]
     assert (
         report_signature.parameters["review_repo"].kind
         is inspect.Parameter.KEYWORD_ONLY
     )
     assert report_signature.parameters["review_repo"].default is None
+    assert (
+        report_signature.parameters["reference_ids"].kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert report_signature.parameters["reference_ids"].default is None
     assert entity_registry.batch_resolve is batch_resolve
     assert entity_registry.batch_resolve_with_report is batch_resolve_with_report
     assert entity_registry.BatchReferenceInput is BatchReferenceInput
@@ -590,6 +599,73 @@ def test_batch_resolve_with_report_enqueues_review_items_and_supports_decisions(
     assert len(manual_aliases) == 1
 
 
+def test_batch_resolve_with_report_returns_report_when_review_enqueue_fails() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = FailingAfterSaveCountReviewRepository(fail_after=1)
+    reference_ids = ["ref-review-retry-a", "ref-review-retry-b"]
+    inputs = [
+        {
+            "raw_mention_text": "Unlisted Retry A",
+            "source_context": {"document_id": "doc-retry", "offset": 1},
+        },
+        {
+            "raw_mention_text": "Unlisted Retry B",
+            "source_context": {"document_id": "doc-retry", "offset": 2},
+        },
+    ]
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    report = batch_resolve_with_report(
+        inputs,
+        review_repo=review_repo,
+        reference_ids=reference_ids,
+    )
+
+    assert report.manual_review_reference_ids == reference_ids
+    assert report.unresolved_reference_ids == reference_ids
+    assert report.job.status == "failed"
+    assert len(report.errors) == 1
+    assert "manual review enqueue failed" in report.errors[0]
+    assert "review save failed" in report.errors[0]
+    assert review_repo.find_by_reference(reference_ids[0]) is not None
+    assert review_repo.find_by_reference(reference_ids[1]) is None
+    assert {
+        reference.reference_id
+        for reference in reference_repo._references.values()
+    } == set(reference_ids)
+    assert all(
+        case_repo.find_by_reference(reference_id)
+        for reference_id in reference_ids
+    )
+
+    review_repo.fail_after = None
+    entity_registry.enqueue_batch_manual_review(
+        report,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+
+    assert review_repo.find_by_reference(reference_ids[0]) is not None
+    assert review_repo.find_by_reference(reference_ids[1]) is not None
+
+    retry_report = batch_resolve_with_report(
+        inputs,
+        review_repo=review_repo,
+        reference_ids=reference_ids,
+    )
+
+    assert retry_report.manual_review_reference_ids == reference_ids
+    assert set(reference_repo._references) == set(reference_ids)
+
+
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()
@@ -766,6 +842,19 @@ class FailingAuditReferenceRepository(InMemoryResolutionAuditReferenceRepository
         case: ResolutionCase,
     ) -> None:
         raise RuntimeError("audit failed")
+
+
+class FailingAfterSaveCountReviewRepository(InMemoryReviewRepository):
+    def __init__(self, *, fail_after: int | None) -> None:
+        super().__init__()
+        self.fail_after = fail_after
+        self.save_attempts = 0
+
+    def save(self, item: entity_registry.UnresolvedQueueItem) -> None:
+        self.save_attempts += 1
+        if self.fail_after is not None and self.save_attempts > self.fail_after:
+            raise RuntimeError("review save failed")
+        super().save(item)
 
 
 class StaticNERExtractor:


### PR DESCRIPTION
Closes #36

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/batch.py`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/storage.py`, `tests/test_repository_hygiene.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The combined milestone claims unresolved batch references should be routed into the manual review queue, but batch_resolve() returns only list[MentionResolutionResult] and discards BatchResolutionReport.groups/manual_review_reference_ids. The review side has enqueue_batch_manual_review(), but there is no integrated public path or default review repository wiring, so callers using the required public API cannot enqueue, claim, or audit unresolved batch results without switching to lower-level orchestration and manually stitching repositories together. This breaks the milestone-level closed-loop goal across #9 and #10.

## 实现范围
- 修改文件: `src/entity_registry/batch.py`
- Add a milestone-level orchestration API or extend configured repository context so batch jobs can persist unresolved references and enqueue review items in one supported flow. At minimum expose/run a public report-returning function and document that enqueue_batch_manual_review(report, ...) is required; preferably add tests that batch unresolved output appears in ReviewRepository and can be claimed/decided.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
