### PR TITLE
feat(#43): [milestone-4 review] P0: Canonical ID rule version silently falls back outside contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0",
-    "project-ult-contracts>=0.1.0",
+    "project-ult-contracts>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from contracts.core import ContractBaseModel
 from contracts.schemas import (
+    CANONICAL_ID_RULE_VERSION,
     CanonicalEntity,
     EntityAlias,
     EntityReference,
@@ -15,17 +16,11 @@ from contracts.schemas import (
     ResolutionCase,
 )
 
-try:
-    from contracts.schemas import CANONICAL_ID_RULE_VERSION as _CONTRACT_RULE_VERSION
-except ImportError:
-    _CONTRACT_RULE_VERSION = "1"
-
 
 ContractCanonicalEntity = CanonicalEntity
 ContractEntityAlias = EntityAlias
 ContractEntityReference = EntityReference
 ContractResolutionCase = ResolutionCase
-CANONICAL_ID_RULE_VERSION = _CONTRACT_RULE_VERSION
 _NO_CANDIDATE_ENTITY_ID = "ENT_UNRESOLVED_NO_CANDIDATE"
 _NO_CANDIDATE_ENTITY_TYPE = "unresolved"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 import sys
 from pathlib import Path
 
@@ -7,5 +8,14 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS_SRC = PROJECT_ROOT.parent / "contracts" / "src"
 
-if CONTRACTS_SRC.exists():
+
+def _has_installed_contracts_package() -> bool:
+    try:
+        version("project-ult-contracts")
+    except PackageNotFoundError:
+        return False
+    return True
+
+
+if CONTRACTS_SRC.exists() and not _has_installed_contracts_package():
     sys.path.insert(0, str(CONTRACTS_SRC))

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -1,4 +1,9 @@
+import os
+import subprocess
+import sys
+import tomllib
 from datetime import UTC, datetime
+from pathlib import Path
 
 import entity_registry
 import entity_registry.contracts as registry_contracts
@@ -23,6 +28,68 @@ from entity_registry.resolution_types import MentionResolutionResult
 
 
 NOW = datetime(2026, 4, 15, tzinfo=UTC)
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_installed_contracts_dependency_exports_canonical_id_rule_version(
+    tmp_path: Path,
+) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+    env["ENTITY_REGISTRY_CONTRACTS_SRC"] = str(
+        (PROJECT_ROOT.parent / "contracts" / "src").resolve()
+    )
+    script = """
+import importlib.metadata
+import os
+import re
+import sys
+from pathlib import Path
+
+contracts_src = Path(os.environ["ENTITY_REGISTRY_CONTRACTS_SRC"])
+for entry in sys.path:
+    if entry and Path(entry).resolve() == contracts_src:
+        raise AssertionError("sibling contracts/src must not shadow dependency")
+
+import contracts.schemas as contract_schemas
+import entity_registry.contracts as registry_contracts
+
+def version_tuple(value):
+    match = re.match(r"^(\\d+)\\.(\\d+)\\.(\\d+)", value)
+    if match is None:
+        raise AssertionError(f"unsupported contracts version: {value}")
+    return tuple(int(part) for part in match.groups())
+
+installed_version = importlib.metadata.version("project-ult-contracts")
+assert version_tuple(installed_version) >= (0, 1, 1)
+assert isinstance(contract_schemas.CANONICAL_ID_RULE_VERSION, str)
+assert contract_schemas.CANONICAL_ID_RULE_VERSION
+assert (
+    registry_contracts.CANONICAL_ID_RULE_VERSION
+    == contract_schemas.CANONICAL_ID_RULE_VERSION
+)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_project_requires_contracts_release_with_rule_version_export() -> None:
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert any(
+        dependency == "project-ult-contracts>=0.1.1"
+        for dependency in dependencies
+    )
 
 
 def test_entity_registry_reexports_contract_entity_schemas() -> None:


### PR DESCRIPTION
Closes #43

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/batch.py`, `src/entity_registry/core.py`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/storage.py`, `tests/test_repository_hygiene.py`


---
## 背景与目标
Milestone review for milestone-4 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
`entity_registry.contracts` tries to import `CANONICAL_ID_RULE_VERSION` from `contracts.schemas`, but falls back to the hard-coded string `"1"` on `ImportError`. That breaks the stated single-source contract model: if the installed contracts package is too old or mispackaged, entity-registry will emit a locally invented rule version instead of failing fast. Because this value is used as the default across canonical entities, aliases, references, and resolution cases, a stale dependency can silently contaminate all published contract payloads.

## 实现范围
- 修改文件: `src/entity_registry/contracts.py`
- Remove the fallback and require the rule version from `contracts`. Update the `project-ult-contracts` minimum version to the first release that exports the constant, and add a packaging-level test that imports the installed dependency rather than a sibling source tree override.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
