### PR TITLE
feat(#42): [milestone-4 review] P0: Contract schemas are exported but not used by the public API

### DIFF
--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -1,10 +1,13 @@
 """Core public exports for the entity-registry package."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import uuid4
+
 from entity_registry.core import (
     AliasType,
-    CanonicalEntity,
     DecisionType,
-    EntityAlias,
     EntityStatus,
     EntityType,
     FinalStatus,
@@ -15,7 +18,7 @@ from entity_registry.core import (
 from entity_registry.aliases import (
     AliasManager,
     generate_aliases_from_stock_basic,
-    lookup_alias,
+    lookup_alias as _runtime_lookup_alias,
 )
 from entity_registry.contracts import (
     CANONICAL_ID_RULE_VERSION,
@@ -36,8 +39,8 @@ from entity_registry.batch import (
     BatchReferenceInput,
     BatchResolutionOutcome,
     BatchResolutionReport,
-    batch_resolve,
     batch_resolve_with_report,
+    batch_resolve_with_report as _runtime_batch_resolve_with_report,
 )
 from entity_registry.fuzzy import (
     FuzzyCandidate,
@@ -82,13 +85,12 @@ from entity_registry.ner import (
     NullNERExtractor,
 )
 from entity_registry.profile import (
-    CanonicalEntityProfile,
-    get_entity_profile,
+    get_entity_profile as _runtime_get_entity_profile,
 )
 from entity_registry.references import (
-    EntityReference,
-    ResolutionCase,
-    register_unresolved_reference,
+    EntityReference as _RuntimeEntityReference,
+    ResolutionCase as _RuntimeResolutionCase,
+    register_unresolved_reference as _runtime_register_unresolved_reference,
 )
 from entity_registry.review import (
     ManualReviewDecision,
@@ -105,12 +107,12 @@ from entity_registry.review import (
 )
 from entity_registry.resolution import (
     DeterministicMatcher,
-    resolve_mention,
+    resolve_mention_with_repositories as _runtime_resolve_mention_with_repositories,
 )
 from entity_registry.resolution_types import (
     BatchResolutionJob,
     MentionCandidateSet,
-    MentionResolutionResult,
+    MentionResolutionResult as _RuntimeMentionResolutionResult,
     ResolutionContext,
     ResolutionDecision,
 )
@@ -122,6 +124,202 @@ from entity_registry.storage import (
 )
 
 __version__ = "0.1.0"
+
+CanonicalEntity = ContractCanonicalEntity
+EntityAlias = ContractEntityAlias
+EntityReference = ContractEntityReference
+ResolutionCase = ContractResolutionCase
+
+
+def lookup_alias(alias_text: str) -> ContractCanonicalEntity | None:
+    """Return the contract canonical entity for one unambiguous alias hit."""
+
+    entity = _runtime_lookup_alias(alias_text)
+    if entity is None:
+        return None
+    return to_contract_canonical_entity(entity)
+
+
+def register_unresolved_reference(
+    reference: _RuntimeEntityReference | dict[str, object],
+) -> ContractResolutionCase:
+    """Register an unresolved reference and return a contract audit payload."""
+
+    unresolved_reference = _runtime_register_unresolved_reference(reference)
+    case = _RuntimeResolutionCase(
+        case_id=_new_public_case_id(),
+        reference_id=unresolved_reference.reference_id,
+        candidate_entity_ids=[],
+        selected_entity_id=None,
+        decision_type=DecisionType.AUTO,
+        decision_rationale="registered unresolved reference",
+        created_at=unresolved_reference.created_at,
+    )
+    _save_runtime_case_if_configured(case)
+    return to_contract_resolution_case(
+        case,
+        input_alias=unresolved_reference.raw_mention_text,
+        candidate_entities=[],
+        decision=EntityResolutionDecision.UNRESOLVED,
+        confidence=0.0,
+    )
+
+
+def resolve_mention(
+    raw_mention_text: str,
+    context: ResolutionContext | dict[str, object] | None = None,
+) -> ContractResolutionCase:
+    """Resolve one mention and return the contract resolution case."""
+
+    from entity_registry.init import (
+        RepositoryNotConfiguredError,
+        _get_default_repository_context,
+    )
+
+    repository_context = _get_default_repository_context()
+    if (
+        repository_context.reference_repo is None
+        or repository_context.case_repo is None
+    ):
+        raise RepositoryNotConfiguredError(
+            "resolution audit repositories are not configured; "
+            "call configure_default_repositories(..., reference_repo=..., "
+            "case_repo=...) before using public resolution APIs, or use "
+            "configure_default_in_memory_audit_repositories() for tests/local workflows",
+        )
+
+    reference_id = _new_public_reference_id()
+    result = _runtime_resolve_mention_with_repositories(
+        raw_mention_text,
+        context,
+        entity_repo=repository_context.entity_repo,
+        alias_repo=repository_context.alias_repo,
+        reference_repo=repository_context.reference_repo,
+        case_repo=repository_context.case_repo,
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
+        reasoner_client=repository_context.reasoner_client,
+        existing_reference_id=reference_id,
+    )
+    return _contract_case_for_reference(
+        reference_id,
+        raw_mention_text,
+        result,
+        entity_repo=repository_context.entity_repo,
+        case_repo=repository_context.case_repo,
+    )
+
+
+def batch_resolve(
+    references: Sequence[_RuntimeEntityReference | dict[str, object] | str],
+) -> list[ContractResolutionCase]:
+    """Resolve a batch of mentions and return contract resolution cases."""
+
+    from entity_registry.init import _get_default_repository_context
+
+    report = _runtime_batch_resolve_with_report(references)
+    repository_context = _get_default_repository_context()
+    if repository_context.case_repo is None:
+        raise RuntimeError("resolution audit repository context disappeared")
+
+    return [
+        _contract_case_for_reference(
+            outcome.source_reference_id,
+            outcome.result.raw_mention_text,
+            outcome.result,
+            entity_repo=repository_context.entity_repo,
+            case_repo=repository_context.case_repo,
+        )
+        for outcome in report.outcomes
+        if outcome.source_reference_id is not None
+    ]
+
+
+def get_entity_profile(canonical_entity_id: str) -> dict[str, object]:
+    """Return a contract-shaped entity profile payload."""
+
+    profile = _runtime_get_entity_profile(canonical_entity_id)
+    return {
+        "canonical_entity": to_contract_canonical_entity(profile.canonical_entity),
+        "aliases": [
+            to_contract_entity_alias(alias)
+            for alias in profile.aliases
+        ],
+        "cross_listing_group": profile.cross_listing_group,
+        "cross_listing_entity_ids": list(profile.cross_listing_entity_ids),
+    }
+
+
+def _contract_case_for_reference(
+    reference_id: str | None,
+    raw_mention_text: str,
+    result: _RuntimeMentionResolutionResult,
+    *,
+    entity_repo: object,
+    case_repo: ResolutionCaseRepository,
+) -> ContractResolutionCase:
+    if reference_id is None:
+        raise RuntimeError("contract resolution payload requires a source reference ID")
+
+    case = _latest_case_for_reference(case_repo, reference_id)
+    candidate_entities = _candidate_entities_for_case(case, entity_repo)
+    return to_contract_resolution_case(
+        case,
+        input_alias=raw_mention_text,
+        candidate_entities=candidate_entities,
+        decision=_contract_decision_for(case, result),
+        confidence=result.resolution_confidence,
+    )
+
+
+def _latest_case_for_reference(
+    case_repo: ResolutionCaseRepository,
+    reference_id: str,
+) -> _RuntimeResolutionCase:
+    cases = case_repo.find_by_reference(reference_id)
+    if not cases:
+        raise RuntimeError(f"missing resolution case for reference {reference_id}")
+    return max(cases, key=lambda case: case.created_at)
+
+
+def _candidate_entities_for_case(
+    case: _RuntimeResolutionCase,
+    entity_repo: object,
+) -> list[object]:
+    entities = []
+    for entity_id in case.candidate_entity_ids:
+        entity = entity_repo.get(entity_id)
+        if entity is not None:
+            entities.append(entity)
+    return entities
+
+
+def _contract_decision_for(
+    case: _RuntimeResolutionCase,
+    result: _RuntimeMentionResolutionResult,
+) -> EntityResolutionDecision:
+    if result.resolved_entity_id is not None:
+        return EntityResolutionDecision.MATCHED
+    if case.candidate_entity_ids:
+        return EntityResolutionDecision.AMBIGUOUS
+    return EntityResolutionDecision.UNRESOLVED
+
+
+def _save_runtime_case_if_configured(case: _RuntimeResolutionCase) -> None:
+    from entity_registry.init import _get_default_repository_context
+
+    repository_context = _get_default_repository_context()
+    if repository_context.case_repo is not None:
+        repository_context.case_repo.save(case)
+
+
+def _new_public_reference_id() -> str:
+    return f"REF_{uuid4().hex}"
+
+
+def _new_public_case_id() -> str:
+    return f"CASE_{uuid4().hex}"
+
 
 __all__ = [
     "__version__",
@@ -135,7 +333,6 @@ __all__ = [
     "CallableReasonerRuntimeClient",
     "CANONICAL_ID_RULE_VERSION",
     "CanonicalEntity",
-    "CanonicalEntityProfile",
     "ContractBaseModel",
     "ContractCanonicalEntity",
     "ContractEntityAlias",
@@ -165,7 +362,6 @@ __all__ = [
     "LLMDisambiguationResponse",
     "ManualReviewDecision",
     "MentionCandidateSet",
-    "MentionResolutionResult",
     "NERExtractor",
     "NullFuzzyMatcher",
     "NullNERExtractor",

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -40,7 +40,7 @@ from entity_registry.batch import (
     BatchResolutionOutcome,
     BatchResolutionReport,
     batch_resolve_with_report,
-    batch_resolve_with_report as _runtime_batch_resolve_with_report,
+    run_batch_resolution_job as _runtime_run_batch_resolution_job,
 )
 from entity_registry.fuzzy import (
     FuzzyCandidate,
@@ -243,12 +243,62 @@ def batch_resolve(
 ) -> list[ContractResolutionCase]:
     """Resolve a batch of mentions and return contract resolution cases."""
 
-    from entity_registry.init import _get_default_repository_context
+    from entity_registry.init import (
+        RepositoryNotConfiguredError,
+        _get_default_repository_context,
+    )
 
-    report = _runtime_batch_resolve_with_report(references)
     repository_context = _get_default_repository_context()
-    if repository_context.case_repo is None:
-        raise RuntimeError("resolution audit repository context disappeared")
+    if (
+        repository_context.reference_repo is None
+        or repository_context.case_repo is None
+    ):
+        raise RepositoryNotConfiguredError(
+            "resolution audit repositories are not configured; "
+            "call configure_default_repositories(..., reference_repo=..., "
+            "case_repo=...) before using public resolution APIs, or use "
+            "configure_default_in_memory_audit_repositories() for tests/local workflows",
+        )
+
+    normalized_inputs = _public_batch_inputs_with_reference_ids(references)
+
+    def resolve_with_captured_context(
+        raw_mention_text: str,
+        context: ResolutionContext | dict[str, object] | None = None,
+        *,
+        existing_reference_id: str | None = None,
+    ) -> _RuntimeMentionResolutionResult:
+        return _runtime_resolve_mention_with_repositories(
+            raw_mention_text,
+            context,
+            entity_repo=repository_context.entity_repo,
+            alias_repo=repository_context.alias_repo,
+            reference_repo=repository_context.reference_repo,
+            case_repo=repository_context.case_repo,
+            fuzzy_matcher=repository_context.fuzzy_matcher,
+            ner_extractor=repository_context.ner_extractor,
+            reasoner_client=repository_context.reasoner_client,
+            existing_reference_id=existing_reference_id,
+        )
+
+    report = _runtime_run_batch_resolution_job(
+        BatchResolutionJob(
+            job_id=_new_public_batch_job_id(),
+            reference_ids=[
+                item.source_reference_id
+                for item in normalized_inputs
+                if item.source_reference_id is not None
+            ],
+            status="pending",
+        ),
+        normalized_inputs,
+        resolver=resolve_with_captured_context,
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+    )
+    if report.errors:
+        raise RuntimeError(
+            "batch resolution failed: " + "; ".join(report.errors),
+        )
 
     return [
         _contract_case_for_reference(
@@ -261,6 +311,78 @@ def batch_resolve(
         for outcome in report.outcomes
         if outcome.source_reference_id is not None
     ]
+
+
+def _public_batch_inputs_with_reference_ids(
+    references: Sequence[_RuntimeEntityReference | dict[str, object] | str],
+) -> list[BatchReferenceInput]:
+    normalized_inputs: list[BatchReferenceInput] = []
+    seen_reference_ids: set[str] = set()
+    for reference in references:
+        item = _coerce_public_batch_reference_input(reference)
+        if item.source_reference_id is None:
+            item = item.model_copy(
+                update={"source_reference_id": _new_public_reference_id()},
+            )
+        if item.source_reference_id in seen_reference_ids:
+            raise ValueError(
+                "duplicate source_reference_id in batch inputs: "
+                f"{item.source_reference_id}"
+            )
+        seen_reference_ids.add(item.source_reference_id)
+        normalized_inputs.append(item)
+    return normalized_inputs
+
+
+def _coerce_public_batch_reference_input(
+    reference: _RuntimeEntityReference | BatchReferenceInput | dict[str, object] | str,
+) -> BatchReferenceInput:
+    if isinstance(reference, BatchReferenceInput):
+        return reference
+    if isinstance(reference, _RuntimeEntityReference):
+        return BatchReferenceInput(
+            raw_mention_text=reference.raw_mention_text,
+            source_context=dict(reference.source_context),
+            source_reference_id=reference.reference_id,
+        )
+    if isinstance(reference, str):
+        return BatchReferenceInput(raw_mention_text=reference)
+    if isinstance(reference, dict):
+        payload = dict(reference)
+        source_context = payload.get("source_context", {})
+        if source_context is None:
+            source_context = {}
+        if not isinstance(source_context, dict):
+            raise ValueError("source_context must be a dictionary")
+
+        source_reference_id = payload.get("source_reference_id")
+        if source_reference_id is None:
+            source_reference_id = payload.get("reference_id")
+        if source_reference_id is not None and not isinstance(
+            source_reference_id,
+            str,
+        ):
+            raise ValueError("source_reference_id must be a string when provided")
+
+        return BatchReferenceInput(
+            raw_mention_text=_required_public_batch_text(
+                payload,
+                "raw_mention_text",
+            ),
+            source_context=dict(source_context),
+            source_reference_id=source_reference_id,
+        )
+    raise TypeError("batch references must be EntityReference, dict, or str")
+
+
+def _required_public_batch_text(
+    payload: dict[str, object],
+    field_name: str,
+) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
 
 
 def get_entity_profile(canonical_entity_id: str) -> dict[str, object]:
@@ -389,6 +511,10 @@ def _new_public_reference_id() -> str:
 
 def _new_public_case_id() -> str:
     return f"CASE_{uuid4().hex}"
+
+
+def _new_public_batch_job_id() -> str:
+    return f"BATCH_{uuid4().hex}"
 
 
 __all__ = [

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -90,7 +90,7 @@ from entity_registry.profile import (
 from entity_registry.references import (
     EntityReference as _RuntimeEntityReference,
     ResolutionCase as _RuntimeResolutionCase,
-    register_unresolved_reference as _runtime_register_unresolved_reference,
+    _coerce_unresolved_reference,
 )
 from entity_registry.review import (
     ManualReviewDecision,
@@ -107,6 +107,7 @@ from entity_registry.review import (
 )
 from entity_registry.resolution import (
     DeterministicMatcher,
+    ResolutionAuditRepositoryRequiredError,
     resolve_mention_with_repositories as _runtime_resolve_mention_with_repositories,
 )
 from entity_registry.resolution_types import (
@@ -119,6 +120,7 @@ from entity_registry.resolution_types import (
 from entity_registry.storage import (
     InMemoryReviewRepository,
     InMemoryResolutionCaseRepository,
+    ReferenceRepository,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -145,7 +147,28 @@ def register_unresolved_reference(
 ) -> ContractResolutionCase:
     """Register an unresolved reference and return a contract audit payload."""
 
-    unresolved_reference = _runtime_register_unresolved_reference(reference)
+    from entity_registry.init import (
+        RepositoryNotConfiguredError,
+        _get_default_repository_context,
+    )
+
+    repository_context = _get_default_repository_context()
+    if repository_context.reference_repo is None:
+        raise RepositoryNotConfiguredError(
+            "reference audit repository is not configured; "
+            "call configure_default_repositories(..., reference_repo=...) before "
+            "registering unresolved references, or use "
+            "configure_default_in_memory_audit_repositories() for tests/local workflows",
+        )
+    if repository_context.case_repo is None:
+        raise RepositoryNotConfiguredError(
+            "resolution case audit repository is not configured; "
+            "call configure_default_repositories(..., case_repo=...) before "
+            "registering unresolved references, or use "
+            "configure_default_in_memory_audit_repositories() for tests/local workflows",
+        )
+
+    unresolved_reference = _coerce_unresolved_reference(reference)
     case = _RuntimeResolutionCase(
         case_id=_new_public_case_id(),
         reference_id=unresolved_reference.reference_id,
@@ -155,9 +178,14 @@ def register_unresolved_reference(
         decision_rationale="registered unresolved reference",
         created_at=unresolved_reference.created_at,
     )
-    _save_runtime_case_if_configured(case)
-    return to_contract_resolution_case(
+    persisted_case = _save_public_resolution_audit(
+        unresolved_reference,
         case,
+        reference_repo=repository_context.reference_repo,
+        case_repo=repository_context.case_repo,
+    )
+    return to_contract_resolution_case(
+        persisted_case,
         input_alias=unresolved_reference.raw_mention_text,
         candidate_entities=[],
         decision=EntityResolutionDecision.UNRESOLVED,
@@ -305,12 +333,54 @@ def _contract_decision_for(
     return EntityResolutionDecision.UNRESOLVED
 
 
-def _save_runtime_case_if_configured(case: _RuntimeResolutionCase) -> None:
-    from entity_registry.init import _get_default_repository_context
+def _save_public_resolution_audit(
+    reference: _RuntimeEntityReference,
+    case: _RuntimeResolutionCase,
+    *,
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+) -> _RuntimeResolutionCase:
+    save_resolution = getattr(reference_repo, "save_resolution", None)
+    if not callable(save_resolution):
+        raise ResolutionAuditRepositoryRequiredError(
+            "resolution audit writes require a native save_resolution(reference, case) "
+            "unit of work; separate reference/case writes are not supported",
+        )
 
-    repository_context = _get_default_repository_context()
-    if repository_context.case_repo is not None:
-        repository_context.case_repo.save(case)
+    previous_reference = reference_repo.get(reference.reference_id)
+    try:
+        save_resolution(reference, case)
+    except Exception:
+        _restore_reference_after_audit_failure(
+            reference_repo,
+            reference.reference_id,
+            previous_reference,
+        )
+        raise
+
+    persisted_case = case_repo.get(case.case_id)
+    if persisted_case is None:
+        _restore_reference_after_audit_failure(
+            reference_repo,
+            reference.reference_id,
+            previous_reference,
+        )
+        raise RuntimeError(
+            "resolution audit repository did not persist the unresolved "
+            f"resolution case {case.case_id}",
+        )
+    return persisted_case
+
+
+def _restore_reference_after_audit_failure(
+    reference_repo: ReferenceRepository,
+    reference_id: str,
+    previous_reference: _RuntimeEntityReference | None,
+) -> None:
+    if previous_reference is None:
+        reference_repo.delete(reference_id)
+        return
+    reference_repo.save(previous_reference)
 
 
 def _new_public_reference_id() -> str:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -71,7 +71,7 @@ def test_batch_resolve_public_signature_and_exports() -> None:
         is inspect.Parameter.KEYWORD_ONLY
     )
     assert report_signature.parameters["reference_ids"].default is None
-    assert entity_registry.batch_resolve is batch_resolve
+    assert entity_registry.batch_resolve is not batch_resolve
     assert entity_registry.batch_resolve_with_report is batch_resolve_with_report
     assert entity_registry.BatchReferenceInput is BatchReferenceInput
     assert entity_registry.BatchCandidateGroup is BatchCandidateGroup

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import tomllib
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -20,15 +21,28 @@ from entity_registry.core import (
     EntityType,
     ResolutionMethod,
 )
+from entity_registry.init import (
+    FileStockBasicSnapshotReader,
+    initialize_from_stock_basic_into,
+)
 from entity_registry.references import (
     EntityReference as RuntimeEntityReference,
     ResolutionCase as RuntimeResolutionCase,
 )
 from entity_registry.resolution_types import MentionResolutionResult
+from entity_registry.storage import InMemoryAliasRepository, InMemoryEntityRepository
 
 
 NOW = datetime(2026, 4, 15, tzinfo=UTC)
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = PROJECT_ROOT / "tests" / "fixtures" / "stock_basic_sample.json"
+
+
+@pytest.fixture(autouse=True)
+def reset_public_repositories() -> Iterator[None]:
+    entity_registry.reset_default_repositories()
+    yield
+    entity_registry.reset_default_repositories()
 
 
 def test_installed_contracts_dependency_exports_canonical_id_rule_version(
@@ -98,10 +112,71 @@ def test_entity_registry_reexports_contract_entity_schemas() -> None:
     assert registry_contracts.EntityReference is contract_schemas.EntityReference
     assert registry_contracts.ResolutionCase is contract_schemas.ResolutionCase
 
+    assert entity_registry.CanonicalEntity is contract_schemas.CanonicalEntity
+    assert entity_registry.EntityAlias is contract_schemas.EntityAlias
+    assert entity_registry.EntityReference is contract_schemas.EntityReference
+    assert entity_registry.ResolutionCase is contract_schemas.ResolutionCase
     assert entity_registry.ContractCanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.ContractEntityAlias is contract_schemas.EntityAlias
     assert entity_registry.ContractEntityReference is contract_schemas.EntityReference
     assert entity_registry.ContractResolutionCase is contract_schemas.ResolutionCase
+    assert not hasattr(entity_registry, "CanonicalEntityProfile")
+    assert not hasattr(entity_registry, "MentionResolutionResult")
+
+
+def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    entity_registry.configure_default_in_memory_audit_repositories(
+        entity_repo,
+        alias_repo,
+    )
+
+    alias_hit = entity_registry.lookup_alias("贵州茅台")
+    assert alias_hit is not None
+    contract_schemas.CanonicalEntity.model_validate(
+        alias_hit.model_dump(mode="json"),
+    )
+
+    resolution_case = entity_registry.resolve_mention(
+        "贵州茅台",
+        {"source": "contract-boundary-test"},
+    )
+    contract_schemas.ResolutionCase.model_validate(
+        resolution_case.model_dump(mode="json"),
+    )
+
+    batch_cases = entity_registry.batch_resolve(["平安银行", "不存在公司"])
+    assert len(batch_cases) == 2
+    for batch_case in batch_cases:
+        contract_schemas.ResolutionCase.model_validate(
+            batch_case.model_dump(mode="json"),
+        )
+
+    unresolved_case = entity_registry.register_unresolved_reference(
+        {
+            "reference_id": "ref-contract-boundary",
+            "raw_mention_text": "Unknown Corp",
+            "source_context": {"source": "contract-boundary-test"},
+        }
+    )
+    contract_schemas.ResolutionCase.model_validate(
+        unresolved_case.model_dump(mode="json"),
+    )
+
+    profile = entity_registry.get_entity_profile("ENT_STOCK_000001.SZ")
+    contract_schemas.CanonicalEntity.model_validate(
+        profile["canonical_entity"].model_dump(mode="json"),
+    )
+    for alias in profile["aliases"]:
+        contract_schemas.EntityAlias.model_validate(alias.model_dump(mode="json"))
 
 
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 import tomllib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -30,7 +30,12 @@ from entity_registry.references import (
     ResolutionCase as RuntimeResolutionCase,
 )
 from entity_registry.resolution_types import MentionResolutionResult
-from entity_registry.storage import InMemoryAliasRepository, InMemoryEntityRepository
+from entity_registry.storage import (
+    InMemoryAliasRepository,
+    InMemoryEntityRepository,
+    InMemoryResolutionAuditReferenceRepository,
+    InMemoryResolutionCaseRepository,
+)
 
 
 NOW = datetime(2026, 4, 15, tzinfo=UTC)
@@ -177,6 +182,72 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
     )
     for alias in profile["aliases"]:
         contract_schemas.EntityAlias.model_validate(alias.model_dump(mode="json"))
+
+
+def test_root_batch_resolve_uses_one_repository_context_for_audit_conversion() -> None:
+    entity_repo_a = InMemoryEntityRepository()
+    alias_repo_a = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo_a,
+        alias_repo_a,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+
+    entity_repo_b = InMemoryEntityRepository()
+    alias_repo_b = InMemoryAliasRepository()
+    case_repo_a = InMemoryResolutionCaseRepository()
+    case_repo_b = InMemoryResolutionCaseRepository()
+    reference_repo_b = InMemoryResolutionAuditReferenceRepository(case_repo_b)
+    reconfigured = False
+
+    def switch_to_context_b() -> None:
+        nonlocal reconfigured
+        if reconfigured:
+            return
+        reconfigured = True
+        entity_registry.configure_default_repositories(
+            entity_repo_b,
+            alias_repo_b,
+            reference_repo=reference_repo_b,
+            case_repo=case_repo_b,
+        )
+
+    reference_repo_a = ReconfiguringAuditReferenceRepository(
+        case_repo_a,
+        switch_to_context_b,
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo_a,
+        alias_repo_a,
+        reference_repo=reference_repo_a,
+        case_repo=case_repo_a,
+    )
+
+    batch_cases = entity_registry.batch_resolve(
+        [
+            {
+                "reference_id": "ref-root-batch-context-race",
+                "raw_mention_text": "平安银行",
+            }
+        ]
+    )
+
+    assert reconfigured is True
+    default_entity_repo, default_alias_repo = entity_registry.get_default_repositories()
+    assert default_entity_repo is entity_repo_b
+    assert default_alias_repo is alias_repo_b
+    assert case_repo_b.find_by_reference("ref-root-batch-context-race") == []
+
+    persisted_cases = case_repo_a.find_by_reference("ref-root-batch-context-race")
+    assert len(persisted_cases) == 1
+    assert batch_cases[0].resolution_case_id == persisted_cases[0].case_id
+    assert batch_cases[0].resolved_entity is not None
+    assert batch_cases[0].resolved_entity.entity_id == "ENT_STOCK_000001.SZ"
+    contract_schemas.ResolutionCase.model_validate(
+        batch_cases[0].model_dump(mode="json"),
+    )
 
 
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
@@ -433,3 +504,21 @@ def make_case() -> RuntimeResolutionCase:
         decision_rationale="unique deterministic match",
         created_at=NOW,
     )
+
+
+class ReconfiguringAuditReferenceRepository(InMemoryResolutionAuditReferenceRepository):
+    def __init__(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+        callback: Callable[[], None],
+    ) -> None:
+        super().__init__(case_repo)
+        self._callback = callback
+
+    def save_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        super().save_resolution(reference, case)
+        self._callback()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -207,7 +207,8 @@ def test_package_in_memory_audit_helper_configures_public_resolution() -> None:
     result = entity_registry.resolve_mention("贵州茅台")
     unresolved = reference_repo.find_unresolved()
 
-    assert result.resolved_entity_id == "ENT_STOCK_600519.SH"
+    assert result.resolved_entity is not None
+    assert result.resolved_entity.entity_id == "ENT_STOCK_600519.SH"
     assert unresolved == []
     assert len(case_repo.find_by_reference(next(iter(reference_repo._references)))) == 1
 
@@ -252,7 +253,7 @@ def test_public_initialize_from_stock_basic_returns_none_for_fixture_snapshot() 
     entity = entity_registry.lookup_alias("平安银行")
     assert entity is not None
     assert entity.canonical_entity_id == "ENT_STOCK_000001.SZ"
-    assert entity_repo.get("ENT_STOCK_000001.SZ") == entity
+    assert entity_repo.get("ENT_STOCK_000001.SZ") is not None
     assert alias_repo.find_by_entity("ENT_STOCK_000001.SZ")
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -82,5 +82,5 @@ def test_public_get_entity_profile_uses_configured_default_repositories() -> Non
 
     profile = entity_registry.get_entity_profile("ENT_STOCK_000001.SZ")
 
-    assert profile.canonical_entity.display_name == "平安银行"
-    assert {alias.alias_text for alias in profile.aliases} >= {"平安银行", "000001"}
+    assert profile["canonical_entity"].display_name == "平安银行"
+    assert {alias.alias for alias in profile["aliases"]} >= {"平安银行", "000001"}

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -23,6 +23,7 @@ from entity_registry.storage import (
     InMemoryAliasRepository,
     InMemoryEntityRepository,
     InMemoryReferenceRepository,
+    InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
 )
 
@@ -161,11 +162,13 @@ def test_register_unresolved_reference_into_rejects_conflicting_payload(
 
 
 def test_public_register_unresolved_reference_uses_configured_repository() -> None:
-    reference_repo = InMemoryReferenceRepository()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
     entity_registry.configure_default_repositories(
         InMemoryEntityRepository(),
         InMemoryAliasRepository(),
         reference_repo=reference_repo,
+        case_repo=case_repo,
     )
 
     contract_case = entity_registry.register_unresolved_reference(
@@ -177,10 +180,59 @@ def test_public_register_unresolved_reference_uses_configured_repository() -> No
     )
 
     reference = reference_repo.get("ref-public")
+    cases = case_repo.find_by_reference("ref-public")
     assert reference is not None
+    assert len(cases) == 1
     assert reference.resolution_method is ResolutionMethod.UNRESOLVED
+    assert contract_case.resolution_case_id == cases[0].case_id
     assert contract_case.decision is entity_registry.EntityResolutionDecision.UNRESOLVED
     assert contract_case.evidence_refs == ["ref-public"]
+
+
+def test_public_register_unresolved_reference_rejects_non_atomic_audit_repository() -> None:
+    reference_repo = InMemoryReferenceRepository()
+    case_repo = InMemoryResolutionCaseRepository()
+    entity_registry.configure_default_repositories(
+        InMemoryEntityRepository(),
+        InMemoryAliasRepository(),
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(RuntimeError, match="save_resolution"):
+        entity_registry.register_unresolved_reference(
+            {
+                "reference_id": "ref-non-atomic",
+                "raw_mention_text": "Unknown Corp",
+                "source_context": {"source": "fixture"},
+            }
+        )
+
+    assert reference_repo.get("ref-non-atomic") is None
+    assert case_repo.find_by_reference("ref-non-atomic") == []
+
+
+def test_public_register_unresolved_reference_rolls_back_case_write_failure() -> None:
+    case_repo = FailingCaseWriteRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    entity_registry.configure_default_repositories(
+        InMemoryEntityRepository(),
+        InMemoryAliasRepository(),
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(RuntimeError, match="case write failed"):
+        entity_registry.register_unresolved_reference(
+            {
+                "reference_id": "ref-case-failure",
+                "raw_mention_text": "Unknown Corp",
+                "source_context": {"source": "fixture"},
+            }
+        )
+
+    assert reference_repo.get("ref-case-failure") is None
+    assert case_repo.find_by_reference("ref-case-failure") == []
 
 
 def test_register_unresolved_reference_into_rejects_resolved_model() -> None:
@@ -324,3 +376,8 @@ def test_batch_resolution_job_round_trips() -> None:
     restored = BatchResolutionJob.model_validate(job.model_dump(mode="json"))
 
     assert restored == job
+
+
+class FailingCaseWriteRepository(InMemoryResolutionCaseRepository):
+    def _save_unchecked(self, case: ResolutionCase) -> None:
+        raise RuntimeError("case write failed")

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -168,7 +168,7 @@ def test_public_register_unresolved_reference_uses_configured_repository() -> No
         reference_repo=reference_repo,
     )
 
-    reference = entity_registry.register_unresolved_reference(
+    contract_case = entity_registry.register_unresolved_reference(
         {
             "reference_id": "ref-public",
             "raw_mention_text": "Unknown Corp",
@@ -176,8 +176,11 @@ def test_public_register_unresolved_reference_uses_configured_repository() -> No
         }
     )
 
-    assert reference_repo.get("ref-public") == reference
+    reference = reference_repo.get("ref-public")
+    assert reference is not None
     assert reference.resolution_method is ResolutionMethod.UNRESOLVED
+    assert contract_case.decision is entity_registry.EntityResolutionDecision.UNRESOLVED
+    assert contract_case.evidence_refs == ["ref-public"]
 
 
 def test_register_unresolved_reference_into_rejects_resolved_model() -> None:

--- a/tests/test_resolution_llm.py
+++ b/tests/test_resolution_llm.py
@@ -399,8 +399,9 @@ def test_public_resolve_mention_uses_configured_reasoner_client(
     result = entity_registry.resolve_mention("宁德时代", {"market": "A-share"})
 
     references = list(reference_repo._references.values())
-    assert result.resolution_method is ResolutionMethod.LLM
-    assert result.resolved_entity_id == "ENT_STOCK_300750.SZ"
+    assert result.resolved_entity is not None
+    assert result.resolved_entity.entity_id == "ENT_STOCK_300750.SZ"
+    assert result.confidence == 0.86
     assert len(reasoner_client.calls) == 1
     assert case_repo.find_by_reference(references[0].reference_id)[0].decision_type is (
         DecisionType.LLM_ASSISTED
@@ -452,12 +453,10 @@ def test_public_resolve_mention_uses_configured_ner_fuzzy_and_reasoner(
 
     references = list(reference_repo._references.values())
     case = case_repo.find_by_reference(references[0].reference_id)[0]
-    assert result.model_dump(mode="json") == {
-        "raw_mention_text": "公告称宁德时代新能源获增持",
-        "resolved_entity_id": "ENT_STOCK_03750.HK",
-        "resolution_method": "llm",
-        "resolution_confidence": 0.89,
-    }
+    assert result.input_alias == "公告称宁德时代新能源获增持"
+    assert result.resolved_entity is not None
+    assert result.resolved_entity.entity_id == "ENT_STOCK_03750.HK"
+    assert result.confidence == 0.89
     assert ner_extractor.calls == ["公告称宁德时代新能源获增持"]
     assert fuzzy_matcher.calls == ["宁德时代新能源"]
     assert [candidate.canonical_entity_id for candidate in reasoner_client.calls[0].candidates] == [
@@ -530,8 +529,9 @@ def test_public_resolve_mention_uses_one_default_context_snapshot(
 
     references_a = list(reference_repo_a._references.values())
     assert read_count == 1
-    assert result.resolution_method is ResolutionMethod.LLM
-    assert result.resolved_entity_id == "ENT_STOCK_300750.SZ"
+    assert result.resolved_entity is not None
+    assert result.resolved_entity.entity_id == "ENT_STOCK_300750.SZ"
+    assert result.confidence == 0.86
     assert len(reasoner_a.calls) == 1
     assert reasoner_b.calls == []
     assert len(references_a) == 1

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -78,8 +78,8 @@ def test_resolve_mention_public_signature_matches_contract() -> None:
 
 
 def test_package_exports_resolution_public_api() -> None:
-    assert entity_registry.resolve_mention is resolve_mention
-    assert entity_registry.MentionResolutionResult is MentionResolutionResult
+    assert entity_registry.resolve_mention is not resolve_mention
+    assert not hasattr(entity_registry, "MentionResolutionResult")
 
 
 def test_mention_resolution_result_json_shape_is_stable() -> None:
@@ -268,7 +268,8 @@ def test_public_resolve_mention_uses_configured_default_repositories() -> None:
     )
 
     references = saved_references(reference_repo)
-    assert result.resolved_entity_id == "ENT_STOCK_600519.SH"
+    assert result.resolved_entity is not None
+    assert result.resolved_entity.entity_id == "ENT_STOCK_600519.SH"
     assert len(references) == 1
     assert references[0].source_context["source_type"] == "announcement"
 


### PR DESCRIPTION
Closes #42

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/batch.py`, `src/entity_registry/contracts.py`, `src/entity_registry/core.py`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/storage.py`, `tests/test_repository_hygiene.py`


---
## 背景与目标
Milestone review for milestone-4 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The milestone goal is to align public entity and resolution models with `contracts`, but the root package still exposes the local `CanonicalEntity`, `EntityAlias`, `EntityReference`, `ResolutionCase`, `MentionResolutionResult`, and `CanonicalEntityProfile` models as the primary public types. Public functions such as `lookup_alias`, `register_unresolved_reference`, `resolve_mention`, `batch_resolve`, and `get_entity_profile` still return local runtime models or local result models. The new `Contract*` aliases and `to_contract_*` helpers are optional side paths, so callers can continue consuming non-contract payloads and the milestone does not establish `contracts` as the single public contract source.

## 实现范围
- 修改文件: `src/entity_registry/__init__.py`
- Define the module boundary explicitly: either make the public APIs return contract schemas where the issue requires contract payloads, or add named contract-returning APIs and wire all export/audit/downstream paths through them. Add integration tests that call the public APIs and assert the returned serialized payloads validate against `contracts.schemas` without using adapter helpers directly.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
