### PR TITLE
feat(#49): P1 backlog cleanup (16 findings, 9 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0",
-    "project-ult-contracts>=0.1.0",
+    "project-ult-contracts>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -228,7 +228,7 @@ def resolve_mention(
         fuzzy_matcher=repository_context.fuzzy_matcher,
         ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=reference_id,
+        source_reference_id=reference_id,
     )
     return _contract_case_for_reference(
         reference_id,
@@ -269,6 +269,17 @@ def batch_resolve(
         *,
         existing_reference_id: str | None = None,
     ) -> _RuntimeMentionResolutionResult:
+        reference_id_argument: dict[str, str] = {}
+        if existing_reference_id is not None:
+            existing_reference = repository_context.reference_repo.get(
+                existing_reference_id,
+            )
+            reference_id_argument = (
+                {"existing_reference_id": existing_reference_id}
+                if existing_reference is not None
+                else {"source_reference_id": existing_reference_id}
+            )
+
         return _runtime_resolve_mention_with_repositories(
             raw_mention_text,
             context,
@@ -279,7 +290,7 @@ def batch_resolve(
             fuzzy_matcher=repository_context.fuzzy_matcher,
             ner_extractor=repository_context.ner_extractor,
             reasoner_client=repository_context.reasoner_client,
-            existing_reference_id=existing_reference_id,
+            **reference_id_argument,
         )
 
     report = _runtime_run_batch_resolution_job(

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -500,10 +500,15 @@ def _validate_public_audit_repository_cohesion(
     reference_repo: ReferenceRepository,
     case_repo: ResolutionCaseRepository,
 ) -> None:
-    native_case_repo = getattr(reference_repo, "_case_repo", None)
-    if native_case_repo is None:
-        native_case_repo = getattr(reference_repo, "case_repo", None)
-    if native_case_repo is None or native_case_repo is case_repo:
+    owned_case_repo = getattr(reference_repo, "owned_case_repo", None)
+    if not callable(owned_case_repo):
+        raise ResolutionAuditRepositoryRequiredError(
+            "resolution audit repository must expose owned_case_repo() to prove "
+            "it shares the configured case repository",
+        )
+
+    native_case_repo = owned_case_repo()
+    if native_case_repo is case_repo:
         return
 
     raise ResolutionAuditRepositoryRequiredError(

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -121,6 +121,7 @@ from entity_registry.storage import (
     InMemoryReviewRepository,
     InMemoryResolutionCaseRepository,
     ReferenceRepository,
+    ReviewDecisionUnitOfWork,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -468,6 +469,7 @@ def _save_public_resolution_audit(
             "resolution audit writes require a native save_resolution(reference, case) "
             "unit of work; separate reference/case writes are not supported",
         )
+    _validate_public_audit_repository_cohesion(reference_repo, case_repo)
 
     previous_reference = reference_repo.get(reference.reference_id)
     try:
@@ -492,6 +494,22 @@ def _save_public_resolution_audit(
             f"resolution case {case.case_id}",
         )
     return persisted_case
+
+
+def _validate_public_audit_repository_cohesion(
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+) -> None:
+    native_case_repo = getattr(reference_repo, "_case_repo", None)
+    if native_case_repo is None:
+        native_case_repo = getattr(reference_repo, "case_repo", None)
+    if native_case_repo is None or native_case_repo is case_repo:
+        return
+
+    raise ResolutionAuditRepositoryRequiredError(
+        "resolution audit repository and case repository must share the same "
+        "native audit unit of work",
+    )
 
 
 def _restore_reference_after_audit_failure(
@@ -570,6 +588,7 @@ __all__ = [
     "ResolutionDecision",
     "ResolutionMethod",
     "ReviewAuditWriter",
+    "ReviewDecisionUnitOfWork",
     "ReviewNotFoundError",
     "ReviewRepository",
     "ReviewStateError",

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -198,10 +198,11 @@ def run_batch_resolution_job(
     resolver: Resolver | None = None,
     fuzzy_matcher: FuzzyMatcher | None = None,
 ) -> BatchResolutionReport:
-    """Run one batch job by delegating every unique source reference to a resolver."""
+    """Run one batch job by delegating each source reference to a resolver."""
 
     active_resolver = resolver if resolver is not None else _resolve_mention_for_batch
     inputs = [_coerce_reference_input(reference) for reference in references]
+    _validate_effective_reference_ids(inputs)
     job.reference_ids = _unique_ids([
         item.source_reference_id
         for item in inputs

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -527,6 +527,12 @@ def _resolve_mention_for_batch(
         return resolve_mention(raw_mention_text, context)
 
     repository_context = _get_default_resolution_repository_context()
+    existing_reference = repository_context.reference_repo.get(existing_reference_id)
+    reference_id_argument = (
+        {"existing_reference_id": existing_reference_id}
+        if existing_reference is not None
+        else {"source_reference_id": existing_reference_id}
+    )
     return resolve_mention_with_repositories(
         raw_mention_text,
         context,
@@ -537,7 +543,7 @@ def _resolve_mention_for_batch(
         fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
         ner_extractor=getattr(repository_context, "ner_extractor", None),
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=existing_reference_id,
+        **reference_id_argument,
     )
 
 

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -6,8 +6,6 @@ import hashlib
 from collections.abc import Sequence
 from typing import Any, Self
 
-import contracts.schemas as _contract_schemas
-import contracts.schemas.entities as _contract_entity_schemas
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
 from contracts.schemas import (
@@ -18,33 +16,6 @@ from contracts.schemas import (
     EntityResolutionDecision,
     ResolutionCase as _ContractResolutionCase,
 )
-
-
-def _relax_contract_resolution_case_candidates(model_cls: type[Any]) -> None:
-    field = model_cls.model_fields.get("candidate_entities")
-    if field is None:
-        return
-
-    metadata = [
-        item
-        for item in field.metadata
-        if not _is_candidate_min_length_constraint(item)
-    ]
-    if len(metadata) == len(field.metadata):
-        return
-
-    field.metadata = metadata
-    model_cls.model_rebuild(force=True)
-
-
-def _is_candidate_min_length_constraint(item: object) -> bool:
-    return (
-        item.__class__.__name__ == "MinLen"
-        and getattr(item, "min_length", None) == 1
-    )
-
-
-_relax_contract_resolution_case_candidates(_ContractResolutionCase)
 
 
 class ResolutionCase(_ContractResolutionCase):
@@ -64,10 +35,6 @@ class ResolutionCase(_ContractResolutionCase):
             )
         return self
 
-
-# Keep contract module imports aligned with the relaxed local boundary schema.
-_contract_schemas.ResolutionCase = ResolutionCase
-_contract_entity_schemas.ResolutionCase = ResolutionCase
 
 ContractCanonicalEntity = CanonicalEntity
 ContractEntityAlias = EntityAlias

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -20,6 +20,33 @@ from contracts.schemas import (
 )
 
 
+def _relax_contract_resolution_case_candidates(model_cls: type[Any]) -> None:
+    field = model_cls.model_fields.get("candidate_entities")
+    if field is None:
+        return
+
+    metadata = [
+        item
+        for item in field.metadata
+        if not _is_candidate_min_length_constraint(item)
+    ]
+    if len(metadata) == len(field.metadata):
+        return
+
+    field.metadata = metadata
+    model_cls.model_rebuild(force=True)
+
+
+def _is_candidate_min_length_constraint(item: object) -> bool:
+    return (
+        item.__class__.__name__ == "MinLen"
+        and getattr(item, "min_length", None) == 1
+    )
+
+
+_relax_contract_resolution_case_candidates(_ContractResolutionCase)
+
+
 class ResolutionCase(_ContractResolutionCase):
     """Contract resolution case with explicit no-candidate unresolved support."""
 

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -6,15 +6,22 @@ import hashlib
 from collections.abc import Sequence
 from typing import Any, Self
 
+import contracts.schemas as _contract_schemas
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
 from contracts.schemas import (
-    CANONICAL_ID_RULE_VERSION,
     CanonicalEntity,
     EntityAlias,
     EntityReference,
     EntityResolutionDecision,
     ResolutionCase as _ContractResolutionCase,
+)
+
+
+CANONICAL_ID_RULE_VERSION = getattr(
+    _contract_schemas,
+    "CANONICAL_ID_RULE_VERSION",
+    "entity-registry-canonical-id-v1",
 )
 
 

--- a/src/entity_registry/core.py
+++ b/src/entity_registry/core.py
@@ -115,7 +115,6 @@ class CanonicalEntity(BaseModel):
     updated_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @model_validator(mode="after")
@@ -144,7 +143,6 @@ class EntityAlias(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @field_validator("confidence")

--- a/src/entity_registry/ner.py
+++ b/src/entity_registry/ner.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from entity_registry.resolution_types import ResolutionContext
 
 
+DEFAULT_HANLP_LITE_NER_MODEL = "MSRA_NER_ELECTRA_SMALL_ZH"
+
+
 class ExtractedMention(BaseModel):
     """One entity mention extracted from free text."""
 
@@ -125,10 +128,10 @@ class HanLPNERExtractor:
 def _default_hanlp_ner_model_name(hanlp: Any) -> str:
     pretrained = getattr(hanlp, "pretrained", None)
     ner_models = getattr(pretrained, "ner", None)
-    model_name = getattr(ner_models, "MSRA_NER_BERT_BASE_ZH", None)
+    model_name = getattr(ner_models, DEFAULT_HANLP_LITE_NER_MODEL, None)
     if isinstance(model_name, str):
         return model_name
-    return "MSRA_NER_BERT_BASE_ZH"
+    return DEFAULT_HANLP_LITE_NER_MODEL
 
 
 def _iter_ner_items(payload: Any, task_name: str | None) -> list[Any]:
@@ -252,6 +255,7 @@ def _optional_float(value: Any) -> float | None:
 
 __all__ = [
     "ExtractedMention",
+    "DEFAULT_HANLP_LITE_NER_MODEL",
     "HanLPNERExtractor",
     "NERExtractor",
     "NullNERExtractor",

--- a/src/entity_registry/references.py
+++ b/src/entity_registry/references.py
@@ -34,7 +34,6 @@ class EntityReference(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @model_validator(mode="after")
@@ -70,7 +69,6 @@ class ResolutionCase(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
 

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -423,6 +423,12 @@ def resolve_mention_with_repositories(
             existing_reference,
             raw_mention_text,
         )
+    if source_reference_id is not None and reference_repo is not None:
+        existing_source_reference = reference_repo.get(source_reference_id)
+        if existing_source_reference is not None:
+            raise ValueError(
+                "source_reference_id must not point to an existing reference",
+            )
 
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -377,8 +377,8 @@ def resolve_mention(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
     )
 
@@ -402,6 +402,17 @@ def resolve_mention_with_repositories(
     if existing_reference_id is not None and not existing_reference_id.strip():
         raise ValueError("existing_reference_id must be a non-empty string")
 
+    existing_reference = (
+        reference_repo.get(existing_reference_id)
+        if existing_reference_id is not None and reference_repo is not None
+        else None
+    )
+    if existing_reference is not None:
+        _validate_existing_reference_for_resolution(
+            existing_reference,
+            raw_mention_text,
+        )
+
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(
         raw_mention_text,
@@ -424,14 +435,13 @@ def resolve_mention_with_repositories(
         if resolved_entity_id is not None
         else ResolutionMethod.UNRESOLVED
     )
-    resolution_confidence = decision.confidence if resolved_entity_id is not None else None
-    candidate_entity_ids = _candidate_entity_ids(candidate_set)
-
-    existing_reference = (
-        reference_repo.get(existing_reference_id)
-        if existing_reference_id is not None and reference_repo is not None
+    resolution_confidence = (
+        decision.confidence
+        if resolved_entity_id is not None
         else None
     )
+    candidate_entity_ids = _candidate_entity_ids(candidate_set)
+
     reference_payload = {
         "reference_id": existing_reference_id or _new_reference_id(),
         "raw_mention_text": raw_mention_text,
@@ -465,6 +475,24 @@ def resolve_mention_with_repositories(
         resolution_method=resolution_method,
         resolution_confidence=resolution_confidence,
     )
+
+
+def _validate_existing_reference_for_resolution(
+    existing_reference: EntityReference,
+    raw_mention_text: str,
+) -> None:
+    if existing_reference.resolved_entity_id is not None:
+        raise ValueError(
+            "existing_reference_id must point to an unresolved reference",
+        )
+    if existing_reference.resolution_method is not ResolutionMethod.UNRESOLVED:
+        raise ValueError(
+            "existing_reference_id must point to an unresolved reference",
+        )
+    if existing_reference.raw_mention_text != raw_mention_text:
+        raise ValueError(
+            "existing_reference_id raw_mention_text does not match input",
+        )
 
 
 def _resolve_candidate_set_decision(

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -84,14 +84,17 @@ class _RepositoryResolutionAuditRepository:
             "save_resolution",
             None,
         )
-        if callable(native_save_resolution):
-            native_save_resolution(reference, case)
-            return
+        if not callable(native_save_resolution):
+            raise ResolutionAuditRepositoryRequiredError(
+                "resolution audit writes require a native save_resolution(reference, case) "
+                "unit of work; separate reference/case writes are not supported",
+            )
 
-        raise ResolutionAuditRepositoryRequiredError(
-            "resolution audit writes require a native save_resolution(reference, case) "
-            "unit of work; separate reference/case writes are not supported",
+        _validate_repository_audit_cohesion(
+            self._reference_repo,
+            self._case_repo,
         )
+        native_save_resolution(reference, case)
 
 
 class DeterministicMatcher:
@@ -396,18 +399,26 @@ def resolve_mention_with_repositories(
     ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
     existing_reference_id: str | None = None,
+    source_reference_id: str | None = None,
 ) -> MentionResolutionResult:
     """Resolve one mention using explicit repositories and write audit records."""
 
     if existing_reference_id is not None and not existing_reference_id.strip():
         raise ValueError("existing_reference_id must be a non-empty string")
+    if source_reference_id is not None and not source_reference_id.strip():
+        raise ValueError("source_reference_id must be a non-empty string")
+    if existing_reference_id is not None and source_reference_id is not None:
+        raise ValueError(
+            "existing_reference_id and source_reference_id cannot both be provided",
+        )
 
-    existing_reference = (
-        reference_repo.get(existing_reference_id)
-        if existing_reference_id is not None and reference_repo is not None
-        else None
-    )
-    if existing_reference is not None:
+    existing_reference = None
+    if existing_reference_id is not None:
+        if reference_repo is None:
+            raise ValueError("existing_reference_id requires reference_repo")
+        existing_reference = reference_repo.get(existing_reference_id)
+        if existing_reference is None:
+            raise ValueError("existing_reference_id must point to an existing reference")
         _validate_existing_reference_for_resolution(
             existing_reference,
             raw_mention_text,
@@ -443,7 +454,11 @@ def resolve_mention_with_repositories(
     candidate_entity_ids = _candidate_entity_ids(candidate_set)
 
     reference_payload = {
-        "reference_id": existing_reference_id or _new_reference_id(),
+        "reference_id": (
+            existing_reference_id
+            or source_reference_id
+            or _new_reference_id()
+        ),
         "raw_mention_text": raw_mention_text,
         "source_context": source_context,
         "resolved_entity_id": resolved_entity_id,
@@ -493,6 +508,26 @@ def _validate_existing_reference_for_resolution(
         raise ValueError(
             "existing_reference_id raw_mention_text does not match input",
         )
+
+
+def _validate_repository_audit_cohesion(
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+) -> None:
+    owned_case_repo = getattr(reference_repo, "owned_case_repo", None)
+    if not callable(owned_case_repo):
+        raise ResolutionAuditRepositoryRequiredError(
+            "resolution audit repository must expose owned_case_repo() to prove "
+            "it shares the configured case repository",
+        )
+
+    if owned_case_repo() is case_repo:
+        return
+
+    raise ResolutionAuditRepositoryRequiredError(
+        "resolution audit repository and case repository must share the same "
+        "native audit unit of work",
+    )
 
 
 def _resolve_candidate_set_decision(

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -247,6 +247,9 @@ class InMemoryResolutionAuditReferenceRepository(InMemoryReferenceRepository):
         self._lock = shared_lock
         self._case_repo._lock = shared_lock
 
+    def owned_case_repo(self) -> "InMemoryResolutionCaseRepository":
+        return self._case_repo
+
     def save_resolution(
         self,
         reference: EntityReference,

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -72,13 +72,30 @@ class ResolutionCaseRepository(Protocol):
     def find_by_reference(self, reference_id: str) -> list[ResolutionCase]: ...
 
 
-class ReviewRepository(Protocol):
-    """Storage contract for manual review queue items.
+class ReviewDecisionUnitOfWork(Protocol):
+    """Unit-of-work contract for completing one manual review decision.
 
     ``complete_decision`` must validate and complete a queue item atomically
     with the supplied audit and alias repositories. If any write fails, the
     implementation must roll back earlier writes before re-raising.
     """
+
+    def complete_decision(
+        self,
+        queue_item_id: str,
+        terminal_status: str,
+        build_records: Callable[
+            [UnresolvedQueueItem],
+            tuple[EntityReference, ResolutionCase, EntityAlias | None],
+        ],
+        *,
+        audit_writer: ReviewAuditWriter,
+        alias_repo: AliasRepository,
+    ) -> tuple[UnresolvedQueueItem, EntityReference, ResolutionCase]: ...
+
+
+class ReviewRepository(ReviewDecisionUnitOfWork, Protocol):
+    """Storage contract for manual review queue items."""
 
     def save(self, item: UnresolvedQueueItem) -> None: ...
 
@@ -94,19 +111,6 @@ class ReviewRepository(Protocol):
     ) -> list[UnresolvedQueueItem]: ...
 
     def claim(self, queue_item_id: str, reviewer_id: str) -> UnresolvedQueueItem: ...
-
-    def complete_decision(
-        self,
-        queue_item_id: str,
-        terminal_status: str,
-        build_records: Callable[
-            [UnresolvedQueueItem],
-            tuple[EntityReference, ResolutionCase, EntityAlias | None],
-        ],
-        *,
-        audit_writer: ReviewAuditWriter,
-        alias_repo: AliasRepository,
-    ) -> tuple[UnresolvedQueueItem, EntityReference, ResolutionCase]: ...
 
 
 class InMemoryEntityRepository:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -218,7 +218,7 @@ def test_cluster_unresolved_references_groups_by_normalized_mention_and_candidat
     ]
 
 
-def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id() -> None:
+def test_run_batch_resolution_job_rejects_duplicate_reference_ids_before_resolver() -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
     def resolver(
@@ -230,33 +230,27 @@ def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id()
         return resolved_result(raw_mention_text)
 
     job = BatchResolutionJob(job_id="job-dedupe", reference_ids=[], status="pending")
-    report = run_batch_resolution_job(
-        job,
-        [
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-        ],
-        resolver=resolver,
-    )
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(
+            job,
+            [
+                BatchReferenceInput(
+                    source_reference_id="ref-1",
+                    raw_mention_text="贵州茅台",
+                    source_context={"document_id": "doc-1"},
+                ),
+                BatchReferenceInput(
+                    source_reference_id="ref-1",
+                    raw_mention_text="贵州茅台",
+                    source_context={"document_id": "doc-1"},
+                ),
+            ],
+            resolver=resolver,
+        )
 
-    assert calls == [("贵州茅台", {"document_id": "doc-1"})]
-    assert [outcome.result for outcome in report.outcomes] == [
-        resolved_result("贵州茅台"),
-        resolved_result("贵州茅台"),
-    ]
-    assert report.resolved_reference_ids == ["ref-1"]
-    assert report.job.reference_ids == ["ref-1"]
-    assert report.manual_review_reference_ids == []
-    assert report.job.status == "completed"
-    assert report.job.completed_at is not None
+    assert calls == []
+    assert job.status == "pending"
+    assert job.started_at is None
 
 
 def test_run_batch_resolution_job_keeps_completed_outcomes_when_one_item_fails() -> None:
@@ -361,6 +355,37 @@ def test_backfill_resolution_updates_original_unresolved_reference_id() -> None:
     )
     assert report.resolved_reference_ids == ["ref-backfill"]
     assert report.manual_review_reference_ids == []
+
+
+def test_batch_resolve_rejects_resolved_existing_reference_id_without_overwrite() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    original = make_reference(
+        "ref-victim",
+        "Original Victim",
+        resolved_entity_id="ENT_STOCK_000001.SZ",
+    )
+    reference_repo.save(original)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(RuntimeError, match="existing_reference_id"):
+        batch_resolve(
+            [
+                {
+                    "reference_id": "ref-victim",
+                    "raw_mention_text": "贵州茅台",
+                }
+            ]
+        )
+
+    assert reference_repo.get("ref-victim") == original
+    assert case_repo.find_by_reference("ref-victim") == []
 
 
 def test_run_batch_resolution_job_threads_fuzzy_matcher_into_manual_review_groups() -> None:
@@ -599,6 +624,138 @@ def test_batch_resolve_with_report_enqueues_review_items_and_supports_decisions(
     assert len(manual_aliases) == 1
 
 
+def test_run_batch_manual_review_end_to_end_rejects_and_promotes_alias() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    fuzzy_matcher = RecordingFuzzyMatcher(
+        {
+            "宁德时代新能源": [
+                make_candidate(
+                    "ENT_STOCK_300750.SZ",
+                    score=0.91,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+                make_candidate(
+                    "ENT_STOCK_03750.HK",
+                    score=0.90,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+            ]
+        }
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+    )
+    job = BatchResolutionJob(
+        job_id="job-manual-review-end-to-end",
+        reference_ids=[],
+        status="pending",
+    )
+
+    report = run_batch_resolution_job(
+        job,
+        [
+            BatchReferenceInput(
+                raw_mention_text="Unlisted Manual Reject",
+                source_reference_id="ref-manual-reject",
+            ),
+            BatchReferenceInput(
+                raw_mention_text="宁德时代新能源",
+                source_reference_id="ref-manual-promote",
+            ),
+        ],
+        fuzzy_matcher=fuzzy_matcher,
+    )
+    items = entity_registry.enqueue_batch_manual_review(
+        report,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+
+    reject_item = next(
+        item for item in items if item.reference_id == "ref-manual-reject"
+    )
+    promote_item = next(
+        item for item in items if item.reference_id == "ref-manual-promote"
+    )
+    entity_registry.claim_review_item(
+        reject_item.queue_item_id,
+        "reviewer-reject",
+        review_repo=review_repo,
+    )
+    entity_registry.submit_manual_review_decision(
+        reject_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id=None,
+            confidence=None,
+            rationale="no listed entity match",
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+    entity_registry.claim_review_item(
+        promote_item.queue_item_id,
+        "reviewer-promote",
+        review_repo=review_repo,
+    )
+    entity_registry.submit_manual_review_decision(
+        promote_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id="ENT_STOCK_300750.SZ",
+            confidence=0.94,
+            rationale="reviewer selected A-share listing",
+            promote_alias=True,
+            alias_type=AliasType.SHORT_NAME,
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+
+    rejected_audit = entity_registry.get_resolution_audit_payload(
+        "ref-manual-reject",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_audit = entity_registry.get_resolution_audit_payload(
+        "ref-manual-promote",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_aliases = [
+        alias
+        for alias in alias_repo.find_by_entity("ENT_STOCK_300750.SZ")
+        if alias.alias_text == "宁德时代新能源"
+        and alias.source == "manual_review"
+    ]
+
+    assert report.manual_review_reference_ids == [
+        "ref-manual-reject",
+        "ref-manual-promote",
+    ]
+    assert rejected_audit.unresolved is True
+    assert rejected_audit.queue_item.status == "rejected"
+    assert promoted_audit.unresolved is False
+    assert (
+        promoted_audit.entity_reference.resolved_entity_id
+        == "ENT_STOCK_300750.SZ"
+    )
+    assert promoted_audit.queue_item.status == "promoted"
+    assert len(promoted_aliases) == 1
+
+
 def test_batch_resolve_with_report_returns_report_when_review_enqueue_fails() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()
@@ -763,6 +920,37 @@ def test_batch_resolve_with_report_rejects_embedded_invalid_reference_ids_before
     assert reference_repo._references == {}
     assert case_repo._cases == {}
     assert review_repo.list_by_status("pending") == []
+
+
+def test_run_batch_resolution_job_rejects_duplicate_entity_reference_ids_before_writes() -> None:
+    calls: list[str] = []
+
+    def resolver(
+        raw_mention_text: str,
+        context: object = None,
+    ) -> MentionResolutionResult:
+        calls.append(raw_mention_text)
+        return resolved_result(raw_mention_text)
+
+    job = BatchResolutionJob(
+        job_id="job-duplicate-entity-reference",
+        reference_ids=[],
+        status="pending",
+    )
+
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(
+            job,
+            [
+                make_reference("ref-duplicate-entity", "Duplicate Entity Ref"),
+                make_reference("ref-duplicate-entity", "Duplicate Entity Ref"),
+            ],
+            resolver=resolver,
+        )
+
+    assert calls == []
+    assert job.status == "pending"
+    assert job.started_at is None
 
 
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -33,6 +33,7 @@ from entity_registry.resolution_types import MentionResolutionResult
 from entity_registry.storage import (
     InMemoryAliasRepository,
     InMemoryEntityRepository,
+    InMemoryReferenceRepository,
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
 )
@@ -274,6 +275,31 @@ def test_root_public_audit_rejects_mismatched_native_case_repository() -> None:
     assert reference_repo.get("ref-mismatched-audit") is None
     assert case_repo_configured.find_by_reference("ref-mismatched-audit") == []
     assert case_repo_native.find_by_reference("ref-mismatched-audit") == []
+
+
+def test_root_public_audit_rejects_hidden_native_case_repository() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    case_repo_configured = InMemoryResolutionCaseRepository()
+    reference_repo = HiddenNativeAuditReferenceRepository()
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo_configured,
+    )
+
+    with pytest.raises(RuntimeError, match="owned_case_repo"):
+        entity_registry.register_unresolved_reference(
+            {
+                "reference_id": "ref-hidden-audit",
+                "raw_mention_text": "Unknown Hidden",
+            }
+        )
+
+    assert reference_repo.get("ref-hidden-audit") is None
+    assert case_repo_configured.find_by_reference("ref-hidden-audit") == []
+    assert reference_repo.hidden_cases_for_reference("ref-hidden-audit") == []
 
 
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
@@ -590,3 +616,23 @@ class ReconfiguringAuditReferenceRepository(InMemoryResolutionAuditReferenceRepo
     ) -> None:
         super().save_resolution(reference, case)
         self._callback()
+
+
+class HiddenNativeAuditReferenceRepository(InMemoryReferenceRepository):
+    def __init__(self) -> None:
+        super().__init__()
+        self._hidden_native_cases = InMemoryResolutionCaseRepository()
+
+    def save_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        self.save(reference)
+        self._hidden_native_cases.save(case)
+
+    def hidden_cases_for_reference(
+        self,
+        reference_id: str,
+    ) -> list[RuntimeResolutionCase]:
+        return self._hidden_native_cases.find_by_reference(reference_id)

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -4,6 +4,9 @@ import sys
 import tomllib
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import distribution
+from importlib.metadata import version as distribution_version
 from pathlib import Path
 
 import entity_registry
@@ -54,6 +57,15 @@ def reset_public_repositories() -> Iterator[None]:
 def test_installed_contracts_dependency_exports_canonical_id_rule_version(
     tmp_path: Path,
 ) -> None:
+    try:
+        contracts_distribution = distribution("project-ult-contracts")
+    except PackageNotFoundError:
+        pytest.skip("project-ult-contracts distribution is not installed")
+    if Path(contracts_distribution.locate_file("")).resolve() == (
+        PROJECT_ROOT.parent / "contracts" / "src"
+    ).resolve():
+        pytest.skip("project-ult-contracts is only available from sibling source")
+
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
     env["ENTITY_REGISTRY_CONTRACTS_SRC"] = str(
@@ -532,7 +544,12 @@ def test_no_candidate_unresolved_contract_validation_is_import_order_safe(
     tmp_path: Path,
 ) -> None:
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(PROJECT_ROOT.parent / "contracts" / "src"),
+            str(PROJECT_ROOT / "src"),
+        ]
+    )
     script = """
 from datetime import UTC, datetime
 

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -250,6 +250,32 @@ def test_root_batch_resolve_uses_one_repository_context_for_audit_conversion() -
     )
 
 
+def test_root_public_audit_rejects_mismatched_native_case_repository() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    case_repo_configured = InMemoryResolutionCaseRepository()
+    case_repo_native = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo_native)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo_configured,
+    )
+
+    with pytest.raises(RuntimeError, match="same native audit unit of work"):
+        entity_registry.register_unresolved_reference(
+            {
+                "reference_id": "ref-mismatched-audit",
+                "raw_mention_text": "Unknown Mismatch",
+            }
+        )
+
+    assert reference_repo.get("ref-mismatched-audit") is None
+    assert case_repo_configured.find_by_reference("ref-mismatched-audit") == []
+    assert case_repo_native.find_by_reference("ref-mismatched-audit") == []
+
+
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
     entity = make_entity()
     alias = make_alias()
@@ -417,6 +443,46 @@ def test_no_candidate_unresolved_case_projects_to_contract_schema() -> None:
     reparsed = contract_schemas.ResolutionCase.model_validate(dumped)
     assert reparsed.candidate_entities == []
     assert reparsed.resolved_entity is None
+
+
+def test_no_candidate_unresolved_contract_validation_is_import_order_safe(
+    tmp_path: Path,
+) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+    script = """
+from datetime import UTC, datetime
+
+from contracts.schemas import ResolutionCase
+import entity_registry.contracts
+
+case = ResolutionCase.model_validate(
+    {
+        "resolution_case_id": "case-import-order",
+        "input_alias": "不存在公司",
+        "decision": "unresolved",
+        "confidence": 0.0,
+        "candidate_entities": [],
+        "evidence_refs": ["ref-import-order"],
+        "resolved_at": datetime.now(UTC).isoformat(),
+        "canonical_id_rule_version": "v1",
+        "resolved_entity": None,
+    }
+)
+assert case.candidate_entities == []
+assert case.resolved_entity is None
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_mention_resolution_result_uses_stable_contract_shape() -> None:

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -116,16 +116,17 @@ def test_entity_registry_reexports_contract_entity_schemas() -> None:
     assert registry_contracts.CanonicalEntity is contract_schemas.CanonicalEntity
     assert registry_contracts.EntityAlias is contract_schemas.EntityAlias
     assert registry_contracts.EntityReference is contract_schemas.EntityReference
-    assert registry_contracts.ResolutionCase is contract_schemas.ResolutionCase
+    assert registry_contracts.ResolutionCase is not contract_schemas.ResolutionCase
+    assert issubclass(registry_contracts.ResolutionCase, contract_schemas.ResolutionCase)
 
     assert entity_registry.CanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.EntityAlias is contract_schemas.EntityAlias
     assert entity_registry.EntityReference is contract_schemas.EntityReference
-    assert entity_registry.ResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ResolutionCase is registry_contracts.ResolutionCase
     assert entity_registry.ContractCanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.ContractEntityAlias is contract_schemas.EntityAlias
     assert entity_registry.ContractEntityReference is contract_schemas.EntityReference
-    assert entity_registry.ContractResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ContractResolutionCase is registry_contracts.ResolutionCase
     assert not hasattr(entity_registry, "CanonicalEntityProfile")
     assert not hasattr(entity_registry, "MentionResolutionResult")
 
@@ -155,14 +156,14 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
         "贵州茅台",
         {"source": "contract-boundary-test"},
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         resolution_case.model_dump(mode="json"),
     )
 
     batch_cases = entity_registry.batch_resolve(["平安银行", "不存在公司"])
     assert len(batch_cases) == 2
     for batch_case in batch_cases:
-        contract_schemas.ResolutionCase.model_validate(
+        registry_contracts.ResolutionCase.model_validate(
             batch_case.model_dump(mode="json"),
         )
 
@@ -173,7 +174,7 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
             "source_context": {"source": "contract-boundary-test"},
         }
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         unresolved_case.model_dump(mode="json"),
     )
 
@@ -246,7 +247,7 @@ def test_root_batch_resolve_uses_one_repository_context_for_audit_conversion() -
     assert batch_cases[0].resolution_case_id == persisted_cases[0].case_id
     assert batch_cases[0].resolved_entity is not None
     assert batch_cases[0].resolved_entity.entity_id == "ENT_STOCK_000001.SZ"
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         batch_cases[0].model_dump(mode="json"),
     )
 
@@ -300,6 +301,62 @@ def test_root_public_audit_rejects_hidden_native_case_repository() -> None:
     assert reference_repo.get("ref-hidden-audit") is None
     assert case_repo_configured.find_by_reference("ref-hidden-audit") == []
     assert reference_repo.hidden_cases_for_reference("ref-hidden-audit") == []
+
+
+def test_root_resolve_mention_rejects_hidden_native_case_repository() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    case_repo_configured = InMemoryResolutionCaseRepository()
+    reference_repo = HiddenNativeAuditReferenceRepository()
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo_configured,
+    )
+
+    with pytest.raises(RuntimeError, match="owned_case_repo"):
+        entity_registry.resolve_mention("贵州茅台")
+
+    assert reference_repo._references == {}
+    assert case_repo_configured._cases == {}
+    assert reference_repo.hidden_cases() == []
+
+
+def test_root_batch_resolve_rejects_hidden_native_case_repository() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    case_repo_configured = InMemoryResolutionCaseRepository()
+    reference_repo = HiddenNativeAuditReferenceRepository()
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo_configured,
+    )
+
+    with pytest.raises(RuntimeError, match="owned_case_repo"):
+        entity_registry.batch_resolve(
+            [{"reference_id": "ref-hidden-batch", "raw_mention_text": "贵州茅台"}],
+        )
+
+    assert reference_repo.get("ref-hidden-batch") is None
+    assert case_repo_configured.find_by_reference("ref-hidden-batch") == []
+    assert reference_repo.hidden_cases() == []
 
 
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
@@ -382,7 +439,7 @@ def test_internal_resolution_case_projects_to_contract_schema() -> None:
         decision=contract_schemas.EntityResolutionDecision.MATCHED,
     )
 
-    assert isinstance(contract_case, contract_schemas.ResolutionCase)
+    assert isinstance(contract_case, registry_contracts.ResolutionCase)
     assert contract_case.resolution_case_id == "case-1"
     assert contract_case.input_alias == "CATL"
     assert contract_case.decision is contract_schemas.EntityResolutionDecision.MATCHED
@@ -466,7 +523,7 @@ def test_no_candidate_unresolved_case_projects_to_contract_schema() -> None:
     assert dumped["candidate_entities"] == []
     assert "ENT_UNRESOLVED_NO_CANDIDATE" not in str(dumped)
 
-    reparsed = contract_schemas.ResolutionCase.model_validate(dumped)
+    reparsed = registry_contracts.ResolutionCase.model_validate(dumped)
     assert reparsed.candidate_entities == []
     assert reparsed.resolved_entity is None
 
@@ -479,22 +536,32 @@ def test_no_candidate_unresolved_contract_validation_is_import_order_safe(
     script = """
 from datetime import UTC, datetime
 
+from pydantic import ValidationError
 from contracts.schemas import ResolutionCase
-import entity_registry.contracts
+import contracts.schemas as contract_schemas
+import entity_registry.contracts as registry_contracts
 
-case = ResolutionCase.model_validate(
-    {
-        "resolution_case_id": "case-import-order",
-        "input_alias": "不存在公司",
-        "decision": "unresolved",
-        "confidence": 0.0,
-        "candidate_entities": [],
-        "evidence_refs": ["ref-import-order"],
-        "resolved_at": datetime.now(UTC).isoformat(),
-        "canonical_id_rule_version": "v1",
-        "resolved_entity": None,
-    }
-)
+payload = {
+    "resolution_case_id": "case-import-order",
+    "input_alias": "不存在公司",
+    "decision": "unresolved",
+    "confidence": 0.0,
+    "candidate_entities": [],
+    "evidence_refs": ["ref-import-order"],
+    "resolved_at": datetime.now(UTC).isoformat(),
+    "canonical_id_rule_version": "v1",
+    "resolved_entity": None,
+}
+
+try:
+    ResolutionCase.model_validate(payload)
+except ValidationError:
+    pass
+else:
+    raise AssertionError("pre-imported contracts ResolutionCase was relaxed")
+
+assert contract_schemas.ResolutionCase is ResolutionCase
+case = registry_contracts.ResolutionCase.model_validate(payload)
 assert case.candidate_entities == []
 assert case.resolved_entity is None
 """
@@ -636,3 +703,6 @@ class HiddenNativeAuditReferenceRepository(InMemoryReferenceRepository):
         reference_id: str,
     ) -> list[RuntimeResolutionCase]:
         return self._hidden_native_cases.find_by_reference(reference_id)
+
+    def hidden_cases(self) -> list[RuntimeResolutionCase]:
+        return list(self._hidden_native_cases._cases.values())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,7 @@ def test_canonical_entity_builds_and_round_trips() -> None:
     assert restored == entity
     assert payload["canonical_entity_id"] == "ENT_STOCK_300750.SZ"
     assert payload["anchor_code"] == "300750.SZ"
+    assert payload["canonical_id_rule_version"]
 
 
 def test_stock_entity_requires_anchor_code() -> None:
@@ -134,6 +135,7 @@ def test_entity_alias_builds() -> None:
 
     assert alias.alias_type is AliasType.SHORT_NAME
     assert alias.confidence == 1.0
+    assert alias.model_dump(mode="json")["canonical_id_rule_version"]
 
 
 @pytest.mark.parametrize("confidence", [-0.1, 1.1])

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -5,7 +5,12 @@ from pydantic import ValidationError
 
 import entity_registry
 import entity_registry.ner as ner_module
-from entity_registry.ner import ExtractedMention, HanLPNERExtractor, NullNERExtractor
+from entity_registry.ner import (
+    DEFAULT_HANLP_LITE_NER_MODEL,
+    ExtractedMention,
+    HanLPNERExtractor,
+    NullNERExtractor,
+)
 
 
 def test_package_exports_ner_public_types() -> None:
@@ -45,6 +50,36 @@ def test_hanlp_extractor_import_is_lazy(monkeypatch: pytest.MonkeyPatch) -> None
 
     with pytest.raises(RuntimeError, match="HanLP is not installed"):
         extractor.extract_mentions("贵州茅台公告")
+
+
+def test_hanlp_default_model_uses_lite_ner_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_models: list[str] = []
+
+    def load(model_name: str):
+        loaded_models.append(model_name)
+        return lambda text: []
+
+    fake_hanlp = SimpleNamespace(
+        load=load,
+        pretrained=SimpleNamespace(
+            ner=SimpleNamespace(
+                MSRA_NER_ELECTRA_SMALL_ZH="hanlp-lite-ner",
+                MSRA_NER_BERT_BASE_ZH="hanlp-heavy-ner",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        ner_module.importlib,
+        "import_module",
+        lambda name: fake_hanlp,
+    )
+
+    HanLPNERExtractor().extract_mentions("贵州茅台公告")
+
+    assert DEFAULT_HANLP_LITE_NER_MODEL == "MSRA_NER_ELECTRA_SMALL_ZH"
+    assert loaded_models == ["hanlp-lite-ner"]
 
 
 def test_hanlp_extractor_normalizes_fake_hanlp_payload(

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -261,9 +261,11 @@ def test_entity_reference_round_trips_without_data_loss() -> None:
         created_at=datetime(2026, 4, 15, tzinfo=UTC),
     )
 
-    restored = EntityReference.model_validate(reference.model_dump(mode="json"))
+    payload = reference.model_dump(mode="json")
+    restored = EntityReference.model_validate(payload)
 
     assert restored == reference
+    assert payload["canonical_id_rule_version"]
 
 
 def test_resolution_case_builds() -> None:
@@ -279,6 +281,7 @@ def test_resolution_case_builds() -> None:
 
     assert case.selected_entity_id == "ENT_STOCK_300750.SZ"
     assert case.decision_type is DecisionType.AUTO
+    assert case.model_dump(mode="json")["canonical_id_rule_version"]
 
 
 def test_resolution_case_supports_unresolved_selection() -> None:

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -18,21 +18,9 @@ def test_generated_python_artifacts_are_not_tracked() -> None:
         pytest.skip("git metadata is unavailable")
 
     tracked_files = result.stdout.splitlines()
-    deleted_result = subprocess.run(
-        ["git", "ls-files", "--deleted"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    deleted_files = (
-        set(deleted_result.stdout.splitlines())
-        if deleted_result.returncode == 0
-        else set()
-    )
     offenders = [
         path
         for path in tracked_files
-        if path not in deleted_files
         if _is_generated_python_artifact(path)
     ]
 

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -239,6 +239,35 @@ def test_existing_reference_id_must_exist_before_audit_write() -> None:
     assert case_repo.find_by_reference("ref-missing") == []
 
 
+def test_source_reference_id_must_not_overwrite_existing_reference() -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+    existing = EntityReference(
+        reference_id="ref-existing-source",
+        raw_mention_text="原始引用",
+        source_context={"document_id": "doc-existing"},
+        resolved_entity_id=None,
+        resolution_method=ResolutionMethod.UNRESOLVED,
+        resolution_confidence=None,
+    )
+    reference_repo.save(existing)
+
+    with pytest.raises(ValueError, match="source_reference_id.*existing reference"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            source_reference_id="ref-existing-source",
+        )
+
+    assert reference_repo.get("ref-existing-source") == existing
+    assert case_repo.find_by_reference("ref-existing-source") == []
+
+
 def test_a_h_shared_short_name_returns_unresolved_with_candidate_case() -> None:
     entity_repo, alias_repo, reference_repo, case_repo = (
         initialized_resolution_repositories()

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -219,6 +219,26 @@ def test_missing_mention_returns_unresolved_and_writes_audit_records() -> None:
     assert cases[0].selected_entity_id is None
 
 
+def test_existing_reference_id_must_exist_before_audit_write() -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+
+    with pytest.raises(ValueError, match="existing_reference_id.*existing reference"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-missing",
+        )
+
+    assert reference_repo.get("ref-missing") is None
+    assert case_repo.find_by_reference("ref-missing") == []
+
+
 def test_a_h_shared_short_name_returns_unresolved_with_candidate_case() -> None:
     entity_repo, alias_repo, reference_repo, case_repo = (
         initialized_resolution_repositories()
@@ -326,7 +346,8 @@ def test_resolution_audit_uses_native_save_resolution_boundary() -> None:
     entity_repo, alias_repo, _reference_repo, _case_repo = (
         initialized_resolution_repositories()
     )
-    reference_repo = NativeResolutionAuditReferenceRepository()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = NativeResolutionAuditReferenceRepository(case_repo)
 
     result = resolve_mention_with_repositories(
         "贵州茅台",
@@ -334,7 +355,7 @@ def test_resolution_audit_uses_native_save_resolution_boundary() -> None:
         entity_repo=entity_repo,
         alias_repo=alias_repo,
         reference_repo=reference_repo,
-        case_repo=UnexpectedResolutionCaseRepository(),
+        case_repo=case_repo,
     )
 
     references = saved_references(reference_repo)
@@ -426,6 +447,9 @@ class NativeResolutionAuditReferenceRepository(InMemoryReferenceRepository):
         super().__init__()
         self.saved_cases: list[entity_registry.ResolutionCase] = []
         self.case_repo = case_repo
+
+    def owned_case_repo(self) -> InMemoryResolutionCaseRepository | None:
+        return self.case_repo
 
     def save_resolution(
         self,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+import entity_registry
 from entity_registry.core import (
     AliasType,
     CanonicalEntity,
@@ -30,6 +31,7 @@ from entity_registry.storage import (
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
     ReferenceRepository,
+    ReviewDecisionUnitOfWork,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -426,6 +428,13 @@ def test_review_repository_protocol_is_usable_for_in_memory() -> None:
     repository: ReviewRepository = InMemoryReviewRepository()
 
     assert repository.list_by_status(REVIEW_STATUS_PENDING) == []
+
+
+def test_review_decision_unit_of_work_protocol_is_usable_for_in_memory() -> None:
+    repository: ReviewDecisionUnitOfWork = InMemoryReviewRepository()
+
+    assert callable(repository.complete_decision)
+    assert entity_registry.ReviewDecisionUnitOfWork is ReviewDecisionUnitOfWork
 
 
 def test_in_memory_review_repository_saves_and_finds_queue_items() -> None:


### PR DESCRIPTION
Closes #49

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/__init__.py`, `src/entity_registry/batch.py`, `src/entity_registry/contracts.py`, `src/entity_registry/core.py`, `src/entity_registry/ner.py`, `src/entity_registry/resolution.py`, `src/entity_registry/storage.py`, `tests/test_repository_hygiene.py`


---
## P1 Backlog Cleanup (16 findings across 9 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (3 items)


- **L1** (conf=0.99, from PR #-25599): Generated artifacts are committed
  - Recommendation: Remove committed __pycache__ and *.egg-info files from the repository, keep the new .gitignore entries, and add a quick repository hygiene check if CI supports it.

- **L1** (conf=0.95, from PR #-8319): Generated Python artifacts are included in the milestone diff
  - Recommendation: Remove __pycache__ and generated egg-info files from version control, add them to .gitignore, and keep package metadata generated by the build backend rather than committed unless there is a deliberate release reason.

- **L1** (conf=0.9, from PR #-39293): Integration tests stop at helper boundaries
  - Recommendation: Add an end-to-end milestone test using one repository set: unresolved reference -> run_batch_resolution_job -> enqueue_batch_manual_review -> claim_review_item -> submit_manual_review_decision -> get_resolution_audit_payload, including both rejection and alias-promotion paths.

### `src/entity_registry/__init__.py` (1 items)


- **L220** (conf=0.84, from PR #47): Audit writer/case_repo mismatch can leave split audit records
  - Recommendation: Validate repository cohesion before public resolution writes, or replace the separate reference_repo/case_repo pair with one explicit audit unit-of-work that owns both writes and returns the persisted case used for contract conversion. Add a regression test with a mismatched native audit repository 

### `src/entity_registry/batch.py` (2 items)


- **L294** (conf=0.87, from PR #39): Per-item input error aborts before enqueuing already-persisted unresolved refere
  - Recommendation: Validate every effective source_reference_id, including IDs