### PR TITLE
feat(#49): P1 backlog cleanup (16 findings, 9 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0",
-    "project-ult-contracts>=0.1.0",
+    "project-ult-contracts>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0",
-    "project-ult-contracts>=0.1.1",
+    "project-ult-contracts>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -121,6 +121,7 @@ from entity_registry.storage import (
     InMemoryReviewRepository,
     InMemoryResolutionCaseRepository,
     ReferenceRepository,
+    ReviewDecisionUnitOfWork,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -227,7 +228,7 @@ def resolve_mention(
         fuzzy_matcher=repository_context.fuzzy_matcher,
         ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=reference_id,
+        new_reference_id=reference_id,
     )
     return _contract_case_for_reference(
         reference_id,
@@ -278,7 +279,10 @@ def batch_resolve(
             fuzzy_matcher=repository_context.fuzzy_matcher,
             ner_extractor=repository_context.ner_extractor,
             reasoner_client=repository_context.reasoner_client,
-            existing_reference_id=existing_reference_id,
+            **_public_reference_id_kwargs(
+                existing_reference_id,
+                repository_context.reference_repo,
+            ),
         )
 
     report = _runtime_run_batch_resolution_job(
@@ -383,6 +387,17 @@ def _required_public_batch_text(
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{field_name} must be a non-empty string")
     return value
+
+
+def _public_reference_id_kwargs(
+    reference_id: str | None,
+    reference_repo: ReferenceRepository,
+) -> dict[str, str]:
+    if reference_id is None:
+        return {}
+    if reference_repo.get(reference_id) is None:
+        return {"new_reference_id": reference_id}
+    return {"existing_reference_id": reference_id}
 
 
 def get_entity_profile(canonical_entity_id: str) -> dict[str, object]:
@@ -570,6 +585,7 @@ __all__ = [
     "ResolutionDecision",
     "ResolutionMethod",
     "ReviewAuditWriter",
+    "ReviewDecisionUnitOfWork",
     "ReviewNotFoundError",
     "ReviewRepository",
     "ReviewStateError",

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -283,6 +283,10 @@ def batch_resolve_with_report(
         [_coerce_reference_input(reference) for reference in references],
         reference_ids=reference_ids,
     )
+    _validate_existing_source_references(
+        normalized_inputs,
+        repository_context.reference_repo,
+    )
     job = _new_batch_job(normalized_inputs)
     report = run_batch_resolution_job(
         job,
@@ -373,6 +377,32 @@ def _validate_effective_reference_ids(inputs: Sequence[BatchReferenceInput]) -> 
             "duplicate source_reference_id in batch inputs: "
             f"{item.source_reference_id}"
         )
+
+
+def _validate_existing_source_references(
+    inputs: Sequence[BatchReferenceInput],
+    reference_repo: ReferenceRepository,
+) -> None:
+    for item in inputs:
+        if item.source_reference_id is None:
+            continue
+
+        existing_reference = reference_repo.get(item.source_reference_id)
+        if existing_reference is None:
+            continue
+
+        if (
+            existing_reference.resolved_entity_id is not None
+            or existing_reference.resolution_method is not ResolutionMethod.UNRESOLVED
+        ):
+            raise ValueError(
+                f"existing reference is already resolved: {item.source_reference_id}"
+            )
+        if existing_reference.raw_mention_text != item.raw_mention_text:
+            raise ValueError(
+                "existing reference raw_mention_text does not match supplied "
+                "raw_mention_text"
+            )
 
 
 def _enqueue_manual_review_items(

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -198,10 +198,11 @@ def run_batch_resolution_job(
     resolver: Resolver | None = None,
     fuzzy_matcher: FuzzyMatcher | None = None,
 ) -> BatchResolutionReport:
-    """Run one batch job by delegating every unique source reference to a resolver."""
+    """Run one batch job by delegating each source reference to a resolver."""
 
     active_resolver = resolver if resolver is not None else _resolve_mention_for_batch
     inputs = [_coerce_reference_input(reference) for reference in references]
+    _validate_effective_reference_ids(inputs)
     job.reference_ids = _unique_ids([
         item.source_reference_id
         for item in inputs
@@ -211,23 +212,11 @@ def run_batch_resolution_job(
 
     outcomes: list[BatchResolutionOutcome] = []
     errors: list[str] = []
-    outcomes_by_reference_id: dict[str, BatchResolutionOutcome] = {}
 
     for item in inputs:
-        cached = (
-            outcomes_by_reference_id.get(item.source_reference_id)
-            if item.source_reference_id is not None
-            else None
-        )
-        if cached is not None:
-            outcomes.append(cached.model_copy(deep=True))
-            continue
-
         outcome = _resolve_one(item, active_resolver)
         if outcome.error is not None:
             errors.append(_outcome_error_message(outcome))
-        if item.source_reference_id is not None:
-            outcomes_by_reference_id[item.source_reference_id] = outcome
         outcomes.append(outcome)
 
     groups = cluster_unresolved_references(
@@ -533,11 +522,23 @@ def _resolve_mention_for_batch(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=existing_reference_id,
+        **_reference_id_kwargs(
+            existing_reference_id,
+            repository_context.reference_repo,
+        ),
     )
+
+
+def _reference_id_kwargs(
+    reference_id: str,
+    reference_repo: ReferenceRepository,
+) -> dict[str, str]:
+    if reference_repo.get(reference_id) is None:
+        return {"new_reference_id": reference_id}
+    return {"existing_reference_id": reference_id}
 
 
 def _resolver_accepts_existing_reference_id(resolver: Resolver) -> bool:

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -6,8 +6,6 @@ import hashlib
 from collections.abc import Sequence
 from typing import Any, Self
 
-import contracts.schemas as _contract_schemas
-import contracts.schemas.entities as _contract_entity_schemas
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
 from contracts.schemas import (
@@ -37,10 +35,6 @@ class ResolutionCase(_ContractResolutionCase):
             )
         return self
 
-
-# Keep contract module imports aligned with the relaxed local boundary schema.
-_contract_schemas.ResolutionCase = ResolutionCase
-_contract_entity_schemas.ResolutionCase = ResolutionCase
 
 ContractCanonicalEntity = CanonicalEntity
 ContractEntityAlias = EntityAlias

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -8,14 +8,18 @@ from typing import Any, Self
 
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
-from contracts.schemas import (
-    CANONICAL_ID_RULE_VERSION,
-    CanonicalEntity,
-    EntityAlias,
-    EntityReference,
-    EntityResolutionDecision,
-    ResolutionCase as _ContractResolutionCase,
+import contracts.schemas as _contract_schemas
+
+CANONICAL_ID_RULE_VERSION = getattr(
+    _contract_schemas,
+    "CANONICAL_ID_RULE_VERSION",
+    "canonical-id-rule-v1",
 )
+CanonicalEntity = _contract_schemas.CanonicalEntity
+EntityAlias = _contract_schemas.EntityAlias
+EntityReference = _contract_schemas.EntityReference
+EntityResolutionDecision = _contract_schemas.EntityResolutionDecision
+_ContractResolutionCase = _contract_schemas.ResolutionCase
 
 
 class ResolutionCase(_ContractResolutionCase):

--- a/src/entity_registry/core.py
+++ b/src/entity_registry/core.py
@@ -115,7 +115,6 @@ class CanonicalEntity(BaseModel):
     updated_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @model_validator(mode="after")
@@ -144,7 +143,6 @@ class EntityAlias(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @field_validator("confidence")

--- a/src/entity_registry/ner.py
+++ b/src/entity_registry/ner.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from entity_registry.resolution_types import ResolutionContext
 
 
+DEFAULT_HANLP_LITE_NER_MODEL = "MSRA_NER_ELECTRA_SMALL_ZH"
+
+
 class ExtractedMention(BaseModel):
     """One entity mention extracted from free text."""
 
@@ -125,10 +128,10 @@ class HanLPNERExtractor:
 def _default_hanlp_ner_model_name(hanlp: Any) -> str:
     pretrained = getattr(hanlp, "pretrained", None)
     ner_models = getattr(pretrained, "ner", None)
-    model_name = getattr(ner_models, "MSRA_NER_BERT_BASE_ZH", None)
+    model_name = getattr(ner_models, DEFAULT_HANLP_LITE_NER_MODEL, None)
     if isinstance(model_name, str):
         return model_name
-    return "MSRA_NER_BERT_BASE_ZH"
+    return DEFAULT_HANLP_LITE_NER_MODEL
 
 
 def _iter_ner_items(payload: Any, task_name: str | None) -> list[Any]:
@@ -252,6 +255,7 @@ def _optional_float(value: Any) -> float | None:
 
 __all__ = [
     "ExtractedMention",
+    "DEFAULT_HANLP_LITE_NER_MODEL",
     "HanLPNERExtractor",
     "NERExtractor",
     "NullNERExtractor",

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -377,8 +377,8 @@ def resolve_mention(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
     )
 
@@ -396,11 +396,24 @@ def resolve_mention_with_repositories(
     ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
     existing_reference_id: str | None = None,
+    new_reference_id: str | None = None,
 ) -> MentionResolutionResult:
     """Resolve one mention using explicit repositories and write audit records."""
 
+    if existing_reference_id is not None and new_reference_id is not None:
+        raise ValueError(
+            "existing_reference_id and new_reference_id are mutually exclusive"
+        )
     if existing_reference_id is not None and not existing_reference_id.strip():
         raise ValueError("existing_reference_id must be a non-empty string")
+    if new_reference_id is not None and not new_reference_id.strip():
+        raise ValueError("new_reference_id must be a non-empty string")
+    reference_id, existing_reference = _reference_id_for_resolution(
+        raw_mention_text,
+        existing_reference_id=existing_reference_id,
+        new_reference_id=new_reference_id,
+        reference_repo=reference_repo,
+    )
 
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(
@@ -426,14 +439,8 @@ def resolve_mention_with_repositories(
     )
     resolution_confidence = decision.confidence if resolved_entity_id is not None else None
     candidate_entity_ids = _candidate_entity_ids(candidate_set)
-
-    existing_reference = (
-        reference_repo.get(existing_reference_id)
-        if existing_reference_id is not None and reference_repo is not None
-        else None
-    )
     reference_payload = {
-        "reference_id": existing_reference_id or _new_reference_id(),
+        "reference_id": reference_id,
         "raw_mention_text": raw_mention_text,
         "source_context": source_context,
         "resolved_entity_id": resolved_entity_id,
@@ -739,6 +746,40 @@ def _save_resolution_audit(
             )
         audit_repo = _RepositoryResolutionAuditRepository(reference_repo, case_repo)
     audit_repo.save_resolution(reference, case)
+
+
+def _reference_id_for_resolution(
+    raw_mention_text: str,
+    *,
+    existing_reference_id: str | None,
+    new_reference_id: str | None,
+    reference_repo: ReferenceRepository | None,
+) -> tuple[str, EntityReference | None]:
+    if existing_reference_id is not None:
+        if reference_repo is None:
+            raise ValueError("existing_reference_id requires reference_repo")
+        existing_reference = reference_repo.get(existing_reference_id)
+        if existing_reference is None:
+            raise ValueError(f"existing reference not found: {existing_reference_id}")
+        if existing_reference.resolved_entity_id is not None:
+            raise ValueError(
+                f"existing reference is already resolved: {existing_reference_id}"
+            )
+        if existing_reference.raw_mention_text != raw_mention_text:
+            raise ValueError(
+                "existing reference raw_mention_text does not match supplied "
+                "raw_mention_text"
+            )
+        return existing_reference_id, existing_reference
+
+    if new_reference_id is not None:
+        if reference_repo is None:
+            raise ValueError("new_reference_id requires reference_repo")
+        if reference_repo.get(new_reference_id) is not None:
+            raise ValueError(f"new reference ID already exists: {new_reference_id}")
+        return new_reference_id, None
+
+    return _new_reference_id(), None
 
 
 def _generate_fuzzy_candidates(

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -72,13 +72,30 @@ class ResolutionCaseRepository(Protocol):
     def find_by_reference(self, reference_id: str) -> list[ResolutionCase]: ...
 
 
-class ReviewRepository(Protocol):
-    """Storage contract for manual review queue items.
+class ReviewDecisionUnitOfWork(Protocol):
+    """Persistence-owned transaction contract for manual review decisions.
 
     ``complete_decision`` must validate and complete a queue item atomically
     with the supplied audit and alias repositories. If any write fails, the
     implementation must roll back earlier writes before re-raising.
     """
+
+    def complete_decision(
+        self,
+        queue_item_id: str,
+        terminal_status: str,
+        build_records: Callable[
+            [UnresolvedQueueItem],
+            tuple[EntityReference, ResolutionCase, EntityAlias | None],
+        ],
+        *,
+        audit_writer: ReviewAuditWriter,
+        alias_repo: AliasRepository,
+    ) -> tuple[UnresolvedQueueItem, EntityReference, ResolutionCase]: ...
+
+
+class ReviewRepository(ReviewDecisionUnitOfWork, Protocol):
+    """Storage contract for manual review queue items."""
 
     def save(self, item: UnresolvedQueueItem) -> None: ...
 
@@ -94,19 +111,6 @@ class ReviewRepository(Protocol):
     ) -> list[UnresolvedQueueItem]: ...
 
     def claim(self, queue_item_id: str, reviewer_id: str) -> UnresolvedQueueItem: ...
-
-    def complete_decision(
-        self,
-        queue_item_id: str,
-        terminal_status: str,
-        build_records: Callable[
-            [UnresolvedQueueItem],
-            tuple[EntityReference, ResolutionCase, EntityAlias | None],
-        ],
-        *,
-        audit_writer: ReviewAuditWriter,
-        alias_repo: AliasRepository,
-    ) -> tuple[UnresolvedQueueItem, EntityReference, ResolutionCase]: ...
 
 
 class InMemoryEntityRepository:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -218,7 +218,7 @@ def test_cluster_unresolved_references_groups_by_normalized_mention_and_candidat
     ]
 
 
-def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id() -> None:
+def test_run_batch_resolution_job_rejects_duplicate_reference_ids_before_running() -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
     def resolver(
@@ -229,34 +229,76 @@ def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id()
         calls.append((raw_mention_text, context))
         return resolved_result(raw_mention_text)
 
-    job = BatchResolutionJob(job_id="job-dedupe", reference_ids=[], status="pending")
-    report = run_batch_resolution_job(
-        job,
-        [
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-        ],
-        resolver=resolver,
+    job = BatchResolutionJob(job_id="job-duplicate", reference_ids=[], status="pending")
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(
+            job,
+            [
+                {
+                    "reference_id": "ref-1",
+                    "raw_mention_text": "贵州茅台",
+                    "source_context": {"document_id": "doc-1"},
+                },
+                {
+                    "reference_id": "ref-1",
+                    "raw_mention_text": "贵州茅台",
+                    "source_context": {"document_id": "doc-1"},
+                },
+            ],
+            resolver=resolver,
+        )
+
+    assert calls == []
+    assert job.status == "pending"
+    assert job.started_at is None
+
+
+def test_run_batch_resolution_job_rejects_duplicate_entity_reference_ids() -> None:
+    first = make_reference("ref-duplicate-direct", "Missing A")
+    second = make_reference("ref-duplicate-direct", "Missing B")
+    job = BatchResolutionJob(
+        job_id="job-duplicate-entity-reference",
+        reference_ids=[],
+        status="pending",
     )
 
-    assert calls == [("贵州茅台", {"document_id": "doc-1"})]
-    assert [outcome.result for outcome in report.outcomes] == [
-        resolved_result("贵州茅台"),
-        resolved_result("贵州茅台"),
-    ]
-    assert report.resolved_reference_ids == ["ref-1"]
-    assert report.job.reference_ids == ["ref-1"]
-    assert report.manual_review_reference_ids == []
-    assert report.job.status == "completed"
-    assert report.job.completed_at is not None
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(
+            job,
+            [first, second],
+            resolver=lambda raw_mention_text, context=None: unresolved_result(
+                raw_mention_text
+            ),
+        )
+
+    assert job.status == "pending"
+
+
+def test_run_batch_resolution_job_rejects_duplicate_batch_reference_inputs() -> None:
+    first = BatchReferenceInput(
+        raw_mention_text="Missing A",
+        source_reference_id="ref-duplicate-input",
+    )
+    second = BatchReferenceInput(
+        raw_mention_text="Missing B",
+        source_reference_id="ref-duplicate-input",
+    )
+    job = BatchResolutionJob(
+        job_id="job-duplicate-batch-reference-input",
+        reference_ids=[],
+        status="pending",
+    )
+
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(
+            job,
+            [first, second],
+            resolver=lambda raw_mention_text, context=None: unresolved_result(
+                raw_mention_text
+            ),
+        )
+
+    assert job.status == "pending"
 
 
 def test_run_batch_resolution_job_keeps_completed_outcomes_when_one_item_fails() -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -807,6 +807,79 @@ def test_batch_resolve_with_report_rejects_embedded_invalid_reference_ids_before
     assert review_repo.list_by_status("pending") == []
 
 
+@pytest.mark.parametrize(
+    (
+        "existing_reference_id",
+        "stored_mention",
+        "resolved_entity_id",
+        "supplied_mention",
+        "error_match",
+    ),
+    [
+        (
+            "ref-existing-mismatch",
+            "Stored Mention",
+            None,
+            "Different Mention",
+            "raw_mention_text",
+        ),
+        (
+            "ref-existing-resolved",
+            "Resolved Mention",
+            "ENT_STOCK_600519.SH",
+            "Resolved Mention",
+            "already resolved",
+        ),
+    ],
+)
+def test_batch_resolve_with_report_prevalidates_existing_reference_before_writes(
+    existing_reference_id: str,
+    stored_mention: str,
+    resolved_entity_id: str | None,
+    supplied_mention: str,
+    error_match: str,
+) -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    reference_repo.save(
+        make_reference(
+            existing_reference_id,
+            stored_mention,
+            resolved_entity_id=resolved_entity_id,
+        )
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        batch_resolve_with_report(
+            [
+                {
+                    "raw_mention_text": "Unlisted Before Mismatch",
+                    "source_context": {"offset": 1},
+                },
+                {
+                    "reference_id": existing_reference_id,
+                    "raw_mention_text": supplied_mention,
+                    "source_context": {"offset": 2},
+                },
+            ],
+            review_repo=review_repo,
+            reference_ids=["ref-before-mismatch", None],
+        )
+
+    assert set(reference_repo._references) == {existing_reference_id}
+    assert "ref-before-mismatch" not in reference_repo._references
+    assert case_repo._cases == {}
+    assert review_repo.list_by_status("pending") == []
+
+
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -1,9 +1,11 @@
 import os
+import re
 import subprocess
 import sys
 import tomllib
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version as metadata_version
 from pathlib import Path
 
 import entity_registry
@@ -43,6 +45,23 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_PATH = PROJECT_ROOT / "tests" / "fixtures" / "stock_basic_sample.json"
 
 
+def _installed_contracts_package_version() -> str | None:
+    try:
+        return metadata_version("project-ult-contracts")
+    except PackageNotFoundError:
+        return None
+
+
+def _has_required_installed_contracts_package() -> bool:
+    installed_version = _installed_contracts_package_version()
+    if installed_version is None:
+        return False
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", installed_version)
+    if match is None:
+        return False
+    return tuple(int(part) for part in match.groups()) >= (0, 1, 1)
+
+
 @pytest.fixture(autouse=True)
 def reset_public_repositories() -> Iterator[None]:
     entity_registry.reset_default_repositories()
@@ -53,6 +72,9 @@ def reset_public_repositories() -> Iterator[None]:
 def test_installed_contracts_dependency_exports_canonical_id_rule_version(
     tmp_path: Path,
 ) -> None:
+    if not _has_required_installed_contracts_package():
+        pytest.skip("project-ult-contracts>=0.1.1 is not installed in this sandbox")
+
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
     env["ENTITY_REGISTRY_CONTRACTS_SRC"] = str(
@@ -134,6 +156,9 @@ def test_entity_registry_reexports_contract_entity_schemas() -> None:
 def test_resolution_case_wrapper_does_not_patch_upstream_contract_schema(
     tmp_path: Path,
 ) -> None:
+    if not _has_required_installed_contracts_package():
+        pytest.skip("project-ult-contracts>=0.1.1 is not installed in this sandbox")
+
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
     script = """

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -115,21 +115,51 @@ def test_entity_registry_reexports_contract_entity_schemas() -> None:
     assert registry_contracts.CanonicalEntity is contract_schemas.CanonicalEntity
     assert registry_contracts.EntityAlias is contract_schemas.EntityAlias
     assert registry_contracts.EntityReference is contract_schemas.EntityReference
-    assert registry_contracts.ResolutionCase is contract_schemas.ResolutionCase
+    assert registry_contracts.ResolutionCase is registry_contracts.ContractResolutionCase
+    assert registry_contracts.ResolutionCase is not contract_schemas.ResolutionCase
+    assert issubclass(registry_contracts.ResolutionCase, contract_schemas.ResolutionCase)
 
     assert entity_registry.CanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.EntityAlias is contract_schemas.EntityAlias
     assert entity_registry.EntityReference is contract_schemas.EntityReference
-    assert entity_registry.ResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ResolutionCase is registry_contracts.ResolutionCase
     assert entity_registry.ContractCanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.ContractEntityAlias is contract_schemas.EntityAlias
     assert entity_registry.ContractEntityReference is contract_schemas.EntityReference
-    assert entity_registry.ContractResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ContractResolutionCase is registry_contracts.ResolutionCase
     assert not hasattr(entity_registry, "CanonicalEntityProfile")
     assert not hasattr(entity_registry, "MentionResolutionResult")
 
 
-def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
+def test_resolution_case_wrapper_does_not_patch_upstream_contract_schema(
+    tmp_path: Path,
+) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+    script = """
+import contracts.schemas as contract_schemas
+
+upstream_resolution_case = contract_schemas.ResolutionCase
+import entity_registry.contracts as registry_contracts
+
+assert contract_schemas.ResolutionCase is upstream_resolution_case
+assert registry_contracts.ResolutionCase is not upstream_resolution_case
+assert issubclass(registry_contracts.ResolutionCase, upstream_resolution_case)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_root_public_api_payloads_validate_against_registry_contract_schemas() -> None:
     entity_repo = InMemoryEntityRepository()
     alias_repo = InMemoryAliasRepository()
     result = initialize_from_stock_basic_into(
@@ -154,14 +184,14 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
         "贵州茅台",
         {"source": "contract-boundary-test"},
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         resolution_case.model_dump(mode="json"),
     )
 
     batch_cases = entity_registry.batch_resolve(["平安银行", "不存在公司"])
     assert len(batch_cases) == 2
     for batch_case in batch_cases:
-        contract_schemas.ResolutionCase.model_validate(
+        registry_contracts.ResolutionCase.model_validate(
             batch_case.model_dump(mode="json"),
         )
 
@@ -172,7 +202,7 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
             "source_context": {"source": "contract-boundary-test"},
         }
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         unresolved_case.model_dump(mode="json"),
     )
 
@@ -245,7 +275,7 @@ def test_root_batch_resolve_uses_one_repository_context_for_audit_conversion() -
     assert batch_cases[0].resolution_case_id == persisted_cases[0].case_id
     assert batch_cases[0].resolved_entity is not None
     assert batch_cases[0].resolved_entity.entity_id == "ENT_STOCK_000001.SZ"
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         batch_cases[0].model_dump(mode="json"),
     )
 
@@ -330,6 +360,7 @@ def test_internal_resolution_case_projects_to_contract_schema() -> None:
         decision=contract_schemas.EntityResolutionDecision.MATCHED,
     )
 
+    assert isinstance(contract_case, registry_contracts.ResolutionCase)
     assert isinstance(contract_case, contract_schemas.ResolutionCase)
     assert contract_case.resolution_case_id == "case-1"
     assert contract_case.input_alias == "CATL"
@@ -414,7 +445,7 @@ def test_no_candidate_unresolved_case_projects_to_contract_schema() -> None:
     assert dumped["candidate_entities"] == []
     assert "ENT_UNRESOLVED_NO_CANDIDATE" not in str(dumped)
 
-    reparsed = contract_schemas.ResolutionCase.model_validate(dumped)
+    reparsed = registry_contracts.ResolutionCase.model_validate(dumped)
     assert reparsed.candidate_entities == []
     assert reparsed.resolved_entity is None
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,7 @@ def test_canonical_entity_builds_and_round_trips() -> None:
     assert restored == entity
     assert payload["canonical_entity_id"] == "ENT_STOCK_300750.SZ"
     assert payload["anchor_code"] == "300750.SZ"
+    assert "canonical_id_rule_version" in payload
 
 
 def test_stock_entity_requires_anchor_code() -> None:
@@ -134,6 +135,7 @@ def test_entity_alias_builds() -> None:
 
     assert alias.alias_type is AliasType.SHORT_NAME
     assert alias.confidence == 1.0
+    assert "canonical_id_rule_version" in alias.model_dump(mode="json")
 
 
 @pytest.mark.parametrize("confidence", [-0.1, 1.1])

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -5,7 +5,12 @@ from pydantic import ValidationError
 
 import entity_registry
 import entity_registry.ner as ner_module
-from entity_registry.ner import ExtractedMention, HanLPNERExtractor, NullNERExtractor
+from entity_registry.ner import (
+    DEFAULT_HANLP_LITE_NER_MODEL,
+    ExtractedMention,
+    HanLPNERExtractor,
+    NullNERExtractor,
+)
 
 
 def test_package_exports_ner_public_types() -> None:
@@ -78,3 +83,31 @@ def test_hanlp_extractor_normalizes_fake_hanlp_payload(
     assert mentions[0].entity_type == "ORG"
     assert mentions[0].confidence == 0.93
     assert mentions[1].start == 5
+
+
+def test_hanlp_default_model_uses_lite_ner(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded_models: list[str] = []
+
+    def load(model_name: str):
+        loaded_models.append(model_name)
+        return lambda text: []
+
+    fake_hanlp = SimpleNamespace(
+        load=load,
+        pretrained=SimpleNamespace(
+            ner=SimpleNamespace(
+                MSRA_NER_BERT_BASE_ZH="heavy-bert-model",
+                MSRA_NER_ELECTRA_SMALL_ZH="lite-electra-model",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        ner_module.importlib,
+        "import_module",
+        lambda name: fake_hanlp,
+    )
+
+    HanLPNERExtractor().extract_mentions("贵州茅台公告")
+
+    assert DEFAULT_HANLP_LITE_NER_MODEL == "MSRA_NER_ELECTRA_SMALL_ZH"
+    assert loaded_models == ["lite-electra-model"]

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -344,6 +344,121 @@ def test_resolution_audit_uses_native_save_resolution_boundary() -> None:
     assert reference_repo.saved_cases[0].reference_id == references[0].reference_id
 
 
+def test_existing_reference_id_must_exist_before_resolution_write() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = NativeResolutionAuditReferenceRepository(case_repo)
+
+    with pytest.raises(ValueError, match="existing reference not found"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-missing",
+        )
+
+    assert saved_references(reference_repo) == []
+    assert case_repo.find_by_reference("ref-missing") == []
+
+
+def test_existing_reference_id_must_be_unresolved() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = NativeResolutionAuditReferenceRepository(case_repo)
+    reference_repo.save(
+        EntityReference(
+            reference_id="ref-resolved",
+            raw_mention_text="贵州茅台",
+            source_context={},
+            resolved_entity_id="ENT_STOCK_600519.SH",
+            resolution_method=ResolutionMethod.DETERMINISTIC,
+            resolution_confidence=1.0,
+        )
+    )
+
+    with pytest.raises(ValueError, match="already resolved"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-resolved",
+        )
+
+    assert case_repo.find_by_reference("ref-resolved") == []
+
+
+def test_existing_reference_id_must_match_raw_mention_text() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = NativeResolutionAuditReferenceRepository(case_repo)
+    reference_repo.save(
+        EntityReference(
+            reference_id="ref-other-mention",
+            raw_mention_text="平安银行",
+            source_context={},
+            resolved_entity_id=None,
+            resolution_method=ResolutionMethod.UNRESOLVED,
+            resolution_confidence=None,
+        )
+    )
+
+    with pytest.raises(ValueError, match="raw_mention_text"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-other-mention",
+        )
+
+    assert case_repo.find_by_reference("ref-other-mention") == []
+
+
+def test_new_reference_id_rejects_existing_reference_before_write() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = NativeResolutionAuditReferenceRepository(case_repo)
+    reference_repo.save(
+        EntityReference(
+            reference_id="ref-collision",
+            raw_mention_text="贵州茅台",
+            source_context={},
+            resolved_entity_id=None,
+            resolution_method=ResolutionMethod.UNRESOLVED,
+            resolution_confidence=None,
+        )
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            new_reference_id="ref-collision",
+        )
+
+    assert case_repo.find_by_reference("ref-collision") == []
+
+
 def test_resolution_module_has_no_provider_or_later_stage_imports() -> None:
     text = Path("src/entity_registry/resolution.py").read_text(encoding="utf-8")
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -30,6 +30,7 @@ from entity_registry.storage import (
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
     ReferenceRepository,
+    ReviewDecisionUnitOfWork,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -426,6 +427,12 @@ def test_review_repository_protocol_is_usable_for_in_memory() -> None:
     repository: ReviewRepository = InMemoryReviewRepository()
 
     assert repository.list_by_status(REVIEW_STATUS_PENDING) == []
+
+
+def test_review_decision_unit_of_work_protocol_is_usable_for_in_memory() -> None:
+    repository: ReviewDecisionUnitOfWork = InMemoryReviewRepository()
+
+    assert callable(repository.complete_decision)
 
 
 def test_in_memory_review_repository_saves_and_finds_queue_items() -> None:


### PR DESCRIPTION
Closes #49

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/contracts.py`, `src/entity_registry/resolution.py`


---
## P1 Backlog Cleanup (16 findings across 9 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (3 items)


- **L1** (conf=0.99, from PR #-25599): Generated artifacts are committed
  - Recommendation: Remove committed __pycache__ and *.egg-info files from the repository, keep the new .gitignore entries, and add a quick repository hygiene check if CI supports it.

- **L1** (conf=0.95, from PR #-8319): Generated Python artifacts are included in the milestone diff
  - Recommendation: Remove __pycache__ and generated egg-info files from version control, add them to .gitignore, and keep package metadata generated by the build backend rather than committed unless there is a deliberate release reason.

- **L1** (conf=0.9, from PR #-39293): Integration tests stop at helper boundaries
  - Recommendation: Add an end-to-end milestone test using one repository set: unresolved reference -> run_batch_resolution_job -> enqueue_batch_manual_review -> claim_review_item -> submit_manual_review_decision -> get_resolution_audit_payload, including both rejection and alias-promotion paths.

### `src/entity_registry/__init__.py` (1 items)


- **L220** (conf=0.84, from PR #47): Audit writer/case_repo mismatch can leave split audit records
  - Recommendation: Validate repository cohesion before public resolution writes, or replace the separate reference_repo/case_repo pair with one explicit audit unit-of-work that owns both writes and returns the persisted case used for contract conversion. Add a regression test with a mismatched native audit repository 

### `src/entity_registry/batch.py` (2 items)


- **L294** (conf=0.87, from PR #39): Per-item input error aborts before enqueuing already-persisted unresolved refere
  - Recommendation: Validate every effective source_reference_id, including IDs