### PR TITLE
feat(#49): P1 backlog cleanup (16 findings, 9 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0",
-    "project-ult-contracts>=0.1.0",
+    "project-ult-contracts>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -522,6 +522,10 @@ def _validate_public_audit_repository_cohesion(
     reference_repo: ReferenceRepository,
     case_repo: ResolutionCaseRepository,
 ) -> None:
+    save_resolution = getattr(reference_repo, "save_resolution", None)
+    if not callable(save_resolution):
+        return
+
     for attribute_name in ("_case_repo", "case_repo", "resolution_case_repo"):
         native_case_repo = getattr(reference_repo, attribute_name, None)
         if native_case_repo is None:
@@ -532,6 +536,10 @@ def _validate_public_audit_repository_cohesion(
                 "configured case_repo"
             )
         return
+    raise ValueError(
+        "reference audit repository with native save_resolution must expose "
+        "an explicit case_repo binding matching the configured case_repo"
+    )
 
 
 def _restore_reference_after_audit_failure(

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -41,6 +41,7 @@ from entity_registry.batch import (
     BatchResolutionReport,
     batch_resolve_with_report,
     run_batch_resolution_job as _runtime_run_batch_resolution_job,
+    _validate_existing_reference_inputs,
 )
 from entity_registry.fuzzy import (
     FuzzyCandidate,
@@ -215,6 +216,10 @@ def resolve_mention(
             "case_repo=...) before using public resolution APIs, or use "
             "configure_default_in_memory_audit_repositories() for tests/local workflows",
         )
+    _validate_public_audit_repository_cohesion(
+        repository_context.reference_repo,
+        repository_context.case_repo,
+    )
 
     reference_id = _new_public_reference_id()
     result = _runtime_resolve_mention_with_repositories(
@@ -227,7 +232,7 @@ def resolve_mention(
         fuzzy_matcher=repository_context.fuzzy_matcher,
         ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=reference_id,
+        reference_id=reference_id,
     )
     return _contract_case_for_reference(
         reference_id,
@@ -259,8 +264,16 @@ def batch_resolve(
             "case_repo=...) before using public resolution APIs, or use "
             "configure_default_in_memory_audit_repositories() for tests/local workflows",
         )
+    _validate_public_audit_repository_cohesion(
+        repository_context.reference_repo,
+        repository_context.case_repo,
+    )
 
     normalized_inputs = _public_batch_inputs_with_reference_ids(references)
+    _validate_existing_reference_inputs(
+        normalized_inputs,
+        reference_repo=repository_context.reference_repo,
+    )
 
     def resolve_with_captured_context(
         raw_mention_text: str,
@@ -268,6 +281,16 @@ def batch_resolve(
         *,
         existing_reference_id: str | None = None,
     ) -> _RuntimeMentionResolutionResult:
+        target_reference_kwargs: dict[str, str] = {}
+        if existing_reference_id is not None:
+            existing_reference = repository_context.reference_repo.get(
+                existing_reference_id,
+            )
+            target_reference_kwargs = (
+                {"existing_reference_id": existing_reference_id}
+                if existing_reference is not None
+                else {"reference_id": existing_reference_id}
+            )
         return _runtime_resolve_mention_with_repositories(
             raw_mention_text,
             context,
@@ -278,7 +301,7 @@ def batch_resolve(
             fuzzy_matcher=repository_context.fuzzy_matcher,
             ner_extractor=repository_context.ner_extractor,
             reasoner_client=repository_context.reasoner_client,
-            existing_reference_id=existing_reference_id,
+            **target_reference_kwargs,
         )
 
     report = _runtime_run_batch_resolution_job(
@@ -462,6 +485,7 @@ def _save_public_resolution_audit(
     reference_repo: ReferenceRepository,
     case_repo: ResolutionCaseRepository,
 ) -> _RuntimeResolutionCase:
+    _validate_public_audit_repository_cohesion(reference_repo, case_repo)
     save_resolution = getattr(reference_repo, "save_resolution", None)
     if not callable(save_resolution):
         raise ResolutionAuditRepositoryRequiredError(
@@ -492,6 +516,22 @@ def _save_public_resolution_audit(
             f"resolution case {case.case_id}",
         )
     return persisted_case
+
+
+def _validate_public_audit_repository_cohesion(
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+) -> None:
+    for attribute_name in ("_case_repo", "case_repo", "resolution_case_repo"):
+        native_case_repo = getattr(reference_repo, attribute_name, None)
+        if native_case_repo is None:
+            continue
+        if native_case_repo is not case_repo:
+            raise ValueError(
+                "reference audit repository must write resolution cases to the "
+                "configured case_repo"
+            )
+        return
 
 
 def _restore_reference_after_audit_failure(

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -526,19 +526,29 @@ def _validate_public_audit_repository_cohesion(
     if not callable(save_resolution):
         return
 
-    for attribute_name in ("_case_repo", "case_repo", "resolution_case_repo"):
-        native_case_repo = getattr(reference_repo, attribute_name, None)
-        if native_case_repo is None:
-            continue
+    owned_case_repo = getattr(reference_repo, "owned_case_repo", None)
+    if callable(owned_case_repo):
+        native_case_repo = owned_case_repo()
         if native_case_repo is not case_repo:
             raise ValueError(
                 "reference audit repository must write resolution cases to the "
                 "configured case_repo"
             )
         return
+
+    native_case_repo = getattr(reference_repo, "case_repo", None)
+    if native_case_repo is not None:
+        if native_case_repo is not case_repo:
+            raise ValueError(
+                "reference audit repository must write resolution cases to the "
+                "configured case_repo"
+            )
+        return
+
     raise ValueError(
         "reference audit repository with native save_resolution must expose "
-        "an explicit case_repo binding matching the configured case_repo"
+        "an explicit owned_case_repo() or case_repo binding matching the "
+        "configured case_repo"
     )
 
 

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -22,6 +22,7 @@ from entity_registry.references import EntityReference
 from entity_registry.resolution import (
     resolve_mention,
     resolve_mention_with_repositories,
+    validate_existing_reference_for_update,
 )
 from entity_registry.resolution_types import (
     BatchResolutionJob,
@@ -200,8 +201,19 @@ def run_batch_resolution_job(
 ) -> BatchResolutionReport:
     """Run one batch job by delegating every unique source reference to a resolver."""
 
-    active_resolver = resolver if resolver is not None else _resolve_mention_for_batch
     inputs = [_coerce_reference_input(reference) for reference in references]
+    _validate_effective_reference_ids(inputs)
+    if (
+        resolver is None
+        and resolve_mention is _DEFAULT_RESOLVE_MENTION
+        and _has_source_reference_ids(inputs)
+    ):
+        repository_context = _get_default_resolution_repository_context()
+        _validate_existing_reference_inputs(
+            inputs,
+            reference_repo=repository_context.reference_repo,
+        )
+    active_resolver = resolver if resolver is not None else _resolve_mention_for_batch
     job.reference_ids = _unique_ids([
         item.source_reference_id
         for item in inputs
@@ -264,6 +276,15 @@ def batch_resolve(
     """
 
     normalized_inputs = [_coerce_reference_input(reference) for reference in references]
+    if (
+        resolve_mention is _DEFAULT_RESOLVE_MENTION
+        and _has_source_reference_ids(normalized_inputs)
+    ):
+        repository_context = _get_default_resolution_repository_context()
+        _validate_existing_reference_inputs(
+            normalized_inputs,
+            reference_repo=repository_context.reference_repo,
+        )
     job = _new_batch_job(normalized_inputs)
     report = run_batch_resolution_job(job, normalized_inputs)
     _raise_for_report_errors(report)
@@ -293,6 +314,10 @@ def batch_resolve_with_report(
     normalized_inputs = _ensure_source_reference_ids(
         [_coerce_reference_input(reference) for reference in references],
         reference_ids=reference_ids,
+    )
+    _validate_existing_reference_inputs(
+        normalized_inputs,
+        reference_repo=repository_context.reference_repo,
     )
     job = _new_batch_job(normalized_inputs)
     report = run_batch_resolution_job(
@@ -383,6 +408,30 @@ def _validate_effective_reference_ids(inputs: Sequence[BatchReferenceInput]) -> 
         raise ValueError(
             "duplicate source_reference_id in batch inputs: "
             f"{item.source_reference_id}"
+        )
+
+
+def _has_source_reference_ids(inputs: Sequence[BatchReferenceInput]) -> bool:
+    return any(item.source_reference_id is not None for item in inputs)
+
+
+def _validate_existing_reference_inputs(
+    inputs: Sequence[BatchReferenceInput],
+    *,
+    reference_repo: ReferenceRepository,
+) -> None:
+    for item in inputs:
+        if item.source_reference_id is None:
+            continue
+
+        existing_reference = reference_repo.get(item.source_reference_id)
+        if existing_reference is None:
+            continue
+
+        validate_existing_reference_for_update(
+            existing_reference,
+            existing_reference_id=item.source_reference_id,
+            raw_mention_text=item.raw_mention_text,
         )
 
 
@@ -526,6 +575,12 @@ def _resolve_mention_for_batch(
         return resolve_mention(raw_mention_text, context)
 
     repository_context = _get_default_resolution_repository_context()
+    existing_reference = repository_context.reference_repo.get(existing_reference_id)
+    target_reference_kwargs = (
+        {"existing_reference_id": existing_reference_id}
+        if existing_reference is not None
+        else {"reference_id": existing_reference_id}
+    )
     return resolve_mention_with_repositories(
         raw_mention_text,
         context,
@@ -533,10 +588,10 @@ def _resolve_mention_for_batch(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=existing_reference_id,
+        **target_reference_kwargs,
     )
 
 

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -6,8 +6,6 @@ import hashlib
 from collections.abc import Sequence
 from typing import Any, Self
 
-import contracts.schemas as _contract_schemas
-import contracts.schemas.entities as _contract_entity_schemas
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
 from contracts.schemas import (
@@ -37,10 +35,6 @@ class ResolutionCase(_ContractResolutionCase):
             )
         return self
 
-
-# Keep contract module imports aligned with the relaxed local boundary schema.
-_contract_schemas.ResolutionCase = ResolutionCase
-_contract_entity_schemas.ResolutionCase = ResolutionCase
 
 ContractCanonicalEntity = CanonicalEntity
 ContractEntityAlias = EntityAlias

--- a/src/entity_registry/core.py
+++ b/src/entity_registry/core.py
@@ -115,7 +115,6 @@ class CanonicalEntity(BaseModel):
     updated_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @model_validator(mode="after")
@@ -144,7 +143,6 @@ class EntityAlias(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @field_validator("confidence")

--- a/src/entity_registry/ner.py
+++ b/src/entity_registry/ner.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
     from entity_registry.resolution_types import ResolutionContext
 
 
+DEFAULT_HANLP_LITE_NER_MODEL_NAME = "CLOSE_TOK_POS_NER_SRL_DEP_SDP_CON_ELECTRA_SMALL_ZH"
+DEFAULT_HANLP_LITE_NER_TASK_NAME = "ner/msra"
+
+
 class ExtractedMention(BaseModel):
     """One entity mention extracted from free text."""
 
@@ -82,7 +86,7 @@ class HanLPNERExtractor:
         task_name: str | None = None,
     ) -> None:
         self._model_name = model_name
-        self._task_name = task_name
+        self._task_name = task_name or DEFAULT_HANLP_LITE_NER_TASK_NAME
         self._model: Any | None = None
 
     def extract_mentions(
@@ -124,11 +128,15 @@ class HanLPNERExtractor:
 
 def _default_hanlp_ner_model_name(hanlp: Any) -> str:
     pretrained = getattr(hanlp, "pretrained", None)
-    ner_models = getattr(pretrained, "ner", None)
-    model_name = getattr(ner_models, "MSRA_NER_BERT_BASE_ZH", None)
+    mtl_models = getattr(pretrained, "mtl", None)
+    model_name = getattr(
+        mtl_models,
+        DEFAULT_HANLP_LITE_NER_MODEL_NAME,
+        None,
+    )
     if isinstance(model_name, str):
         return model_name
-    return "MSRA_NER_BERT_BASE_ZH"
+    return DEFAULT_HANLP_LITE_NER_MODEL_NAME
 
 
 def _iter_ner_items(payload: Any, task_name: str | None) -> list[Any]:

--- a/src/entity_registry/references.py
+++ b/src/entity_registry/references.py
@@ -34,7 +34,6 @@ class EntityReference(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @model_validator(mode="after")
@@ -70,7 +69,6 @@ class ResolutionCase(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
 

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -377,8 +377,8 @@ def resolve_mention(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
     )
 
@@ -396,11 +396,24 @@ def resolve_mention_with_repositories(
     ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
     existing_reference_id: str | None = None,
+    reference_id: str | None = None,
 ) -> MentionResolutionResult:
     """Resolve one mention using explicit repositories and write audit records."""
 
     if existing_reference_id is not None and not existing_reference_id.strip():
         raise ValueError("existing_reference_id must be a non-empty string")
+    if reference_id is not None and not reference_id.strip():
+        raise ValueError("reference_id must be a non-empty string")
+    if existing_reference_id is not None and reference_id is not None:
+        raise ValueError("existing_reference_id and reference_id are mutually exclusive")
+
+    existing_reference = _existing_reference_for_resolution(
+        existing_reference_id,
+        raw_mention_text,
+        reference_repo,
+    )
+    if reference_id is not None:
+        _validate_new_reference_id(reference_id, reference_repo)
 
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(
@@ -427,13 +440,9 @@ def resolve_mention_with_repositories(
     resolution_confidence = decision.confidence if resolved_entity_id is not None else None
     candidate_entity_ids = _candidate_entity_ids(candidate_set)
 
-    existing_reference = (
-        reference_repo.get(existing_reference_id)
-        if existing_reference_id is not None and reference_repo is not None
-        else None
-    )
+    target_reference_id = existing_reference_id or reference_id or _new_reference_id()
     reference_payload = {
-        "reference_id": existing_reference_id or _new_reference_id(),
+        "reference_id": target_reference_id,
         "raw_mention_text": raw_mention_text,
         "source_context": source_context,
         "resolved_entity_id": resolved_entity_id,
@@ -465,6 +474,67 @@ def resolve_mention_with_repositories(
         resolution_method=resolution_method,
         resolution_confidence=resolution_confidence,
     )
+
+
+def validate_existing_reference_for_update(
+    existing_reference: EntityReference | None,
+    *,
+    existing_reference_id: str,
+    raw_mention_text: str,
+) -> None:
+    """Validate that an existing reference can be overwritten by a resolver."""
+
+    if existing_reference is None:
+        raise ValueError(f"existing reference not found: {existing_reference_id}")
+    if existing_reference.resolved_entity_id is not None:
+        raise ValueError(
+            "existing_reference_id must point to an unresolved reference: "
+            f"{existing_reference_id}"
+        )
+    if existing_reference.resolution_method is not ResolutionMethod.UNRESOLVED:
+        raise ValueError(
+            "existing_reference_id must point to an unresolved reference: "
+            f"{existing_reference_id}"
+        )
+    if existing_reference.raw_mention_text != raw_mention_text:
+        raise ValueError(
+            "existing_reference_id raw_mention_text mismatch: "
+            f"{existing_reference_id}"
+        )
+
+
+def _existing_reference_for_resolution(
+    existing_reference_id: str | None,
+    raw_mention_text: str,
+    reference_repo: ReferenceRepository | None,
+) -> EntityReference | None:
+    if existing_reference_id is None:
+        return None
+    if reference_repo is None:
+        raise ValueError(
+            "existing_reference_id requires reference_repo validation",
+        )
+
+    existing_reference = reference_repo.get(existing_reference_id)
+    validate_existing_reference_for_update(
+        existing_reference,
+        existing_reference_id=existing_reference_id,
+        raw_mention_text=raw_mention_text,
+    )
+    return existing_reference
+
+
+def _validate_new_reference_id(
+    reference_id: str,
+    reference_repo: ReferenceRepository | None,
+) -> None:
+    if reference_repo is None:
+        return
+    if reference_repo.get(reference_id) is not None:
+        raise ValueError(
+            "reference_id already exists; use existing_reference_id for backfill: "
+            f"{reference_id}"
+        )
 
 
 def _resolve_candidate_set_decision(

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -243,6 +243,9 @@ class InMemoryResolutionAuditReferenceRepository(InMemoryReferenceRepository):
         self._lock = shared_lock
         self._case_repo._lock = shared_lock
 
+    def owned_case_repo(self) -> "InMemoryResolutionCaseRepository":
+        return self._case_repo
+
     def save_resolution(
         self,
         reference: EntityReference,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -218,7 +218,7 @@ def test_cluster_unresolved_references_groups_by_normalized_mention_and_candidat
     ]
 
 
-def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id() -> None:
+def test_run_batch_resolution_job_rejects_duplicate_reference_id_before_running() -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
     def resolver(
@@ -230,33 +230,27 @@ def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id()
         return resolved_result(raw_mention_text)
 
     job = BatchResolutionJob(job_id="job-dedupe", reference_ids=[], status="pending")
-    report = run_batch_resolution_job(
-        job,
-        [
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-        ],
-        resolver=resolver,
-    )
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(
+            job,
+            [
+                {
+                    "reference_id": "ref-1",
+                    "raw_mention_text": "贵州茅台",
+                    "source_context": {"document_id": "doc-1"},
+                },
+                {
+                    "reference_id": "ref-1",
+                    "raw_mention_text": "贵州茅台",
+                    "source_context": {"document_id": "doc-1"},
+                },
+            ],
+            resolver=resolver,
+        )
 
-    assert calls == [("贵州茅台", {"document_id": "doc-1"})]
-    assert [outcome.result for outcome in report.outcomes] == [
-        resolved_result("贵州茅台"),
-        resolved_result("贵州茅台"),
-    ]
-    assert report.resolved_reference_ids == ["ref-1"]
-    assert report.job.reference_ids == ["ref-1"]
-    assert report.manual_review_reference_ids == []
-    assert report.job.status == "completed"
-    assert report.job.completed_at is not None
+    assert calls == []
+    assert job.status == "pending"
+    assert job.started_at is None
 
 
 def test_run_batch_resolution_job_keeps_completed_outcomes_when_one_item_fails() -> None:
@@ -599,6 +593,140 @@ def test_batch_resolve_with_report_enqueues_review_items_and_supports_decisions(
     assert len(manual_aliases) == 1
 
 
+def test_milestone_review_flow_runs_end_to_end_on_one_repository_set() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    fuzzy_matcher = RecordingFuzzyMatcher(
+        {
+            "宁德时代新能源": [
+                make_candidate(
+                    "ENT_STOCK_300750.SZ",
+                    score=0.91,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+                make_candidate(
+                    "ENT_STOCK_03750.HK",
+                    score=0.90,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+            ]
+        }
+    )
+    reject_reference = make_reference(
+        "ref-e2e-reject",
+        "Unlisted Reject",
+        {"document_id": "doc-e2e", "path": "reject"},
+    )
+    promote_reference = make_reference(
+        "ref-e2e-promote",
+        "宁德时代新能源",
+        {"document_id": "doc-e2e", "path": "promote"},
+    )
+    reference_repo.save(reject_reference)
+    reference_repo.save(promote_reference)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+    )
+    job = BatchResolutionJob(job_id="job-e2e-review", reference_ids=[], status="pending")
+
+    report = run_batch_resolution_job(
+        job,
+        collect_unresolved_references(reference_repo),
+    )
+    items = entity_registry.enqueue_batch_manual_review(
+        report,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+
+    assert set(report.manual_review_reference_ids) == {
+        "ref-e2e-reject",
+        "ref-e2e-promote",
+    }
+    assert {item.reference_id for item in items} == {
+        "ref-e2e-reject",
+        "ref-e2e-promote",
+    }
+
+    reject_item = review_repo.find_by_reference("ref-e2e-reject")
+    promote_item = review_repo.find_by_reference("ref-e2e-promote")
+    assert reject_item is not None
+    assert promote_item is not None
+
+    entity_registry.claim_review_item(
+        reject_item.queue_item_id,
+        "reviewer-a",
+        review_repo=review_repo,
+    )
+    entity_registry.submit_manual_review_decision(
+        reject_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id=None,
+            confidence=None,
+            rationale="not a listed entity mention",
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+
+    entity_registry.claim_review_item(
+        promote_item.queue_item_id,
+        "reviewer-b",
+        review_repo=review_repo,
+    )
+    entity_registry.submit_manual_review_decision(
+        promote_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id="ENT_STOCK_300750.SZ",
+            confidence=0.94,
+            rationale="reviewer selected the A-share listing",
+            promote_alias=True,
+            alias_type=AliasType.SHORT_NAME,
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+
+    rejected_audit = entity_registry.get_resolution_audit_payload(
+        "ref-e2e-reject",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_audit = entity_registry.get_resolution_audit_payload(
+        "ref-e2e-promote",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_aliases = [
+        alias
+        for alias in alias_repo.find_by_entity("ENT_STOCK_300750.SZ")
+        if alias.alias_text == "宁德时代新能源"
+        and alias.source == "manual_review"
+    ]
+
+    assert rejected_audit.entity_reference.resolution_method is (
+        ResolutionMethod.UNRESOLVED
+    )
+    assert rejected_audit.queue_item.status == "rejected"
+    assert promoted_audit.entity_reference.resolved_entity_id == "ENT_STOCK_300750.SZ"
+    assert promoted_audit.entity_reference.resolution_method is ResolutionMethod.MANUAL
+    assert promoted_audit.queue_item.status == "promoted"
+    assert len(promoted_aliases) == 1
+
+
 def test_batch_resolve_with_report_returns_report_when_review_enqueue_fails() -> None:
     entity_repo, alias_repo = initialized_repositories()
     case_repo = InMemoryResolutionCaseRepository()
@@ -763,6 +891,73 @@ def test_batch_resolve_with_report_rejects_embedded_invalid_reference_ids_before
     assert reference_repo._references == {}
     assert case_repo._cases == {}
     assert review_repo.list_by_status("pending") == []
+
+
+def test_batch_resolve_with_report_rejects_mismatched_existing_reference_before_writes() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    existing = make_reference("ref-existing", "Original Mention")
+    reference_repo.save(existing)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(ValueError, match="raw_mention_text mismatch"):
+        batch_resolve_with_report(
+            [
+                {
+                    "reference_id": "ref-new-before-error",
+                    "raw_mention_text": "Unlisted Before Error",
+                },
+                {
+                    "reference_id": "ref-existing",
+                    "raw_mention_text": "Different Mention",
+                },
+            ],
+            review_repo=review_repo,
+        )
+
+    assert reference_repo.get("ref-existing") == existing
+    assert reference_repo.get("ref-new-before-error") is None
+    assert case_repo._cases == {}
+    assert review_repo.list_by_status("pending") == []
+
+
+def test_public_batch_resolve_rejects_mismatched_existing_reference_before_writes() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    existing = make_reference("ref-existing-public", "Original Mention")
+    reference_repo.save(existing)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    with pytest.raises(ValueError, match="raw_mention_text mismatch"):
+        entity_registry.batch_resolve(
+            [
+                {
+                    "reference_id": "ref-public-before-error",
+                    "raw_mention_text": "Unlisted Before Error",
+                },
+                {
+                    "reference_id": "ref-existing-public",
+                    "raw_mention_text": "Different Mention",
+                },
+            ]
+        )
+
+    assert reference_repo.get("ref-existing-public") == existing
+    assert reference_repo.get("ref-public-before-error") is None
+    assert case_repo._cases == {}
 
 
 def test_manual_review_routing_keeps_a_h_shared_short_name_unresolved() -> None:

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -115,16 +115,20 @@ def test_entity_registry_reexports_contract_entity_schemas() -> None:
     assert registry_contracts.CanonicalEntity is contract_schemas.CanonicalEntity
     assert registry_contracts.EntityAlias is contract_schemas.EntityAlias
     assert registry_contracts.EntityReference is contract_schemas.EntityReference
-    assert registry_contracts.ResolutionCase is contract_schemas.ResolutionCase
+    assert registry_contracts.ResolutionCase is not contract_schemas.ResolutionCase
+    assert issubclass(
+        registry_contracts.ResolutionCase,
+        contract_schemas.ResolutionCase,
+    )
 
     assert entity_registry.CanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.EntityAlias is contract_schemas.EntityAlias
     assert entity_registry.EntityReference is contract_schemas.EntityReference
-    assert entity_registry.ResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ResolutionCase is registry_contracts.ResolutionCase
     assert entity_registry.ContractCanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.ContractEntityAlias is contract_schemas.EntityAlias
     assert entity_registry.ContractEntityReference is contract_schemas.EntityReference
-    assert entity_registry.ContractResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ContractResolutionCase is registry_contracts.ResolutionCase
     assert not hasattr(entity_registry, "CanonicalEntityProfile")
     assert not hasattr(entity_registry, "MentionResolutionResult")
 
@@ -154,14 +158,14 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
         "贵州茅台",
         {"source": "contract-boundary-test"},
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         resolution_case.model_dump(mode="json"),
     )
 
     batch_cases = entity_registry.batch_resolve(["平安银行", "不存在公司"])
     assert len(batch_cases) == 2
     for batch_case in batch_cases:
-        contract_schemas.ResolutionCase.model_validate(
+        registry_contracts.ResolutionCase.model_validate(
             batch_case.model_dump(mode="json"),
         )
 
@@ -172,7 +176,7 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
             "source_context": {"source": "contract-boundary-test"},
         }
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         unresolved_case.model_dump(mode="json"),
     )
 
@@ -245,9 +249,63 @@ def test_root_batch_resolve_uses_one_repository_context_for_audit_conversion() -
     assert batch_cases[0].resolution_case_id == persisted_cases[0].case_id
     assert batch_cases[0].resolved_entity is not None
     assert batch_cases[0].resolved_entity.entity_id == "ENT_STOCK_000001.SZ"
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ResolutionCase.model_validate(
         batch_cases[0].model_dump(mode="json"),
     )
+
+
+def test_resolution_case_relaxation_does_not_patch_contracts_dependency() -> None:
+    assert contract_schemas.ResolutionCase is not registry_contracts.ResolutionCase
+
+    case = RuntimeResolutionCase(
+        case_id="case-local-unresolved",
+        reference_id="ref-local-unresolved",
+        candidate_entity_ids=[],
+        selected_entity_id=None,
+        decision_type=DecisionType.AUTO,
+        decision_rationale="no candidates",
+        created_at=NOW,
+    )
+    contract_case = registry_contracts.to_contract_resolution_case(
+        case,
+        input_alias="不存在公司",
+        candidate_entities=[],
+        decision=contract_schemas.EntityResolutionDecision.UNRESOLVED,
+    )
+    dumped = contract_case.model_dump(mode="json")
+
+    registry_contracts.ResolutionCase.model_validate(dumped)
+    with pytest.raises(ValueError):
+        contract_schemas.ResolutionCase.model_validate(dumped)
+
+
+def test_public_resolution_rejects_mismatched_native_audit_repositories() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+
+    hidden_case_repo = InMemoryResolutionCaseRepository()
+    configured_case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(hidden_case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=configured_case_repo,
+    )
+
+    with pytest.raises(ValueError, match="configured case_repo"):
+        entity_registry.resolve_mention("贵州茅台")
+
+    assert reference_repo.find_unresolved() == []
+    assert hidden_case_repo._cases == {}
+    assert configured_case_repo._cases == {}
 
 
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
@@ -414,7 +472,7 @@ def test_no_candidate_unresolved_case_projects_to_contract_schema() -> None:
     assert dumped["candidate_entities"] == []
     assert "ENT_UNRESOLVED_NO_CANDIDATE" not in str(dumped)
 
-    reparsed = contract_schemas.ResolutionCase.model_validate(dumped)
+    reparsed = registry_contracts.ResolutionCase.model_validate(dumped)
     assert reparsed.candidate_entities == []
     assert reparsed.resolved_entity is None
 

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -330,7 +330,40 @@ def test_resolve_mention_rejects_hidden_native_audit_repo() -> None:
         case_repo=configured_case_repo,
     )
 
-    with pytest.raises(ValueError, match="explicit case_repo binding"):
+    with pytest.raises(ValueError, match="owned_case_repo"):
+        entity_registry.resolve_mention("贵州茅台")
+
+    assert reference_repo.save_calls == 0
+    assert reference_repo.find_unresolved() == []
+    assert hidden_case_repo._cases == {}
+    assert configured_case_repo._cases == {}
+
+
+def test_resolve_mention_rejects_attr_only_native_audit_repo() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+
+    hidden_case_repo = InMemoryResolutionCaseRepository()
+    configured_case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = AttrOnlyNativeAuditReferenceRepository(
+        configured_case_repo,
+        hidden_case_repo,
+    )
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=configured_case_repo,
+    )
+
+    with pytest.raises(ValueError, match="owned_case_repo"):
         entity_registry.resolve_mention("贵州茅台")
 
     assert reference_repo.save_calls == 0
@@ -618,6 +651,27 @@ class ReconfiguringAuditReferenceRepository(InMemoryResolutionAuditReferenceRepo
 class HiddenNativeAuditReferenceRepository(InMemoryReferenceRepository):
     def __init__(self, hidden_case_repo: InMemoryResolutionCaseRepository) -> None:
         super().__init__()
+        self._hidden_native_store = hidden_case_repo
+        self.save_calls = 0
+
+    def save_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        self.save_calls += 1
+        self.save(reference)
+        self._hidden_native_store.save(case)
+
+
+class AttrOnlyNativeAuditReferenceRepository(InMemoryReferenceRepository):
+    def __init__(
+        self,
+        configured_case_repo: InMemoryResolutionCaseRepository,
+        hidden_case_repo: InMemoryResolutionCaseRepository,
+    ) -> None:
+        super().__init__()
+        self._case_repo = configured_case_repo
         self._hidden_native_store = hidden_case_repo
         self.save_calls = 0
 

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -33,6 +33,7 @@ from entity_registry.resolution_types import MentionResolutionResult
 from entity_registry.storage import (
     InMemoryAliasRepository,
     InMemoryEntityRepository,
+    InMemoryReferenceRepository,
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
 )
@@ -303,6 +304,36 @@ def test_public_resolution_rejects_mismatched_native_audit_repositories() -> Non
     with pytest.raises(ValueError, match="configured case_repo"):
         entity_registry.resolve_mention("贵州茅台")
 
+    assert reference_repo.find_unresolved() == []
+    assert hidden_case_repo._cases == {}
+    assert configured_case_repo._cases == {}
+
+
+def test_resolve_mention_rejects_hidden_native_audit_repo() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+
+    hidden_case_repo = InMemoryResolutionCaseRepository()
+    configured_case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = HiddenNativeAuditReferenceRepository(hidden_case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=configured_case_repo,
+    )
+
+    with pytest.raises(ValueError, match="explicit case_repo binding"):
+        entity_registry.resolve_mention("贵州茅台")
+
+    assert reference_repo.save_calls == 0
     assert reference_repo.find_unresolved() == []
     assert hidden_case_repo._cases == {}
     assert configured_case_repo._cases == {}
@@ -582,3 +613,19 @@ class ReconfiguringAuditReferenceRepository(InMemoryResolutionAuditReferenceRepo
     ) -> None:
         super().save_resolution(reference, case)
         self._callback()
+
+
+class HiddenNativeAuditReferenceRepository(InMemoryReferenceRepository):
+    def __init__(self, hidden_case_repo: InMemoryResolutionCaseRepository) -> None:
+        super().__init__()
+        self._hidden_native_store = hidden_case_repo
+        self.save_calls = 0
+
+    def save_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        self.save_calls += 1
+        self.save(reference)
+        self._hidden_native_store.save(case)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,7 @@ def test_canonical_entity_builds_and_round_trips() -> None:
     assert restored == entity
     assert payload["canonical_entity_id"] == "ENT_STOCK_300750.SZ"
     assert payload["anchor_code"] == "300750.SZ"
+    assert payload["canonical_id_rule_version"] == entity.canonical_id_rule_version
 
 
 def test_stock_entity_requires_anchor_code() -> None:
@@ -134,6 +135,10 @@ def test_entity_alias_builds() -> None:
 
     assert alias.alias_type is AliasType.SHORT_NAME
     assert alias.confidence == 1.0
+    assert (
+        alias.model_dump(mode="json")["canonical_id_rule_version"]
+        == alias.canonical_id_rule_version
+    )
 
 
 @pytest.mark.parametrize("confidence", [-0.1, 1.1])

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -5,7 +5,13 @@ from pydantic import ValidationError
 
 import entity_registry
 import entity_registry.ner as ner_module
-from entity_registry.ner import ExtractedMention, HanLPNERExtractor, NullNERExtractor
+from entity_registry.ner import (
+    DEFAULT_HANLP_LITE_NER_MODEL_NAME,
+    DEFAULT_HANLP_LITE_NER_TASK_NAME,
+    ExtractedMention,
+    HanLPNERExtractor,
+    NullNERExtractor,
+)
 
 
 def test_package_exports_ner_public_types() -> None:
@@ -78,3 +84,32 @@ def test_hanlp_extractor_normalizes_fake_hanlp_payload(
     assert mentions[0].entity_type == "ORG"
     assert mentions[0].confidence == 0.93
     assert mentions[1].start == 5
+
+
+def test_hanlp_extractor_defaults_to_lite_model_and_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_models: list[str] = []
+
+    def load(model_name: str):
+        loaded_models.append(model_name)
+        return lambda text: {DEFAULT_HANLP_LITE_NER_TASK_NAME: ["贵州茅台"]}
+
+    fake_hanlp = SimpleNamespace(
+        load=load,
+        pretrained=SimpleNamespace(
+            mtl=SimpleNamespace(
+                **{DEFAULT_HANLP_LITE_NER_MODEL_NAME: "hanlp-lite-model"}
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        ner_module.importlib,
+        "import_module",
+        lambda name: fake_hanlp,
+    )
+
+    mentions = HanLPNERExtractor().extract_mentions("贵州茅台公告")
+
+    assert loaded_models == ["hanlp-lite-model"]
+    assert [mention.mention_text for mention in mentions] == ["贵州茅台"]

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -264,6 +264,10 @@ def test_entity_reference_round_trips_without_data_loss() -> None:
     restored = EntityReference.model_validate(reference.model_dump(mode="json"))
 
     assert restored == reference
+    assert (
+        reference.model_dump(mode="json")["canonical_id_rule_version"]
+        == reference.canonical_id_rule_version
+    )
 
 
 def test_resolution_case_builds() -> None:
@@ -279,6 +283,10 @@ def test_resolution_case_builds() -> None:
 
     assert case.selected_entity_id == "ENT_STOCK_300750.SZ"
     assert case.decision_type is DecisionType.AUTO
+    assert (
+        case.model_dump(mode="json")["canonical_id_rule_version"]
+        == case.canonical_id_rule_version
+    )
 
 
 def test_resolution_case_supports_unresolved_selection() -> None:

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -18,21 +18,9 @@ def test_generated_python_artifacts_are_not_tracked() -> None:
         pytest.skip("git metadata is unavailable")
 
     tracked_files = result.stdout.splitlines()
-    deleted_result = subprocess.run(
-        ["git", "ls-files", "--deleted"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    deleted_files = (
-        set(deleted_result.stdout.splitlines())
-        if deleted_result.returncode == 0
-        else set()
-    )
     offenders = [
         path
         for path in tracked_files
-        if path not in deleted_files
         if _is_generated_python_artifact(path)
     ]
 

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -1,5 +1,6 @@
 import inspect
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -245,6 +246,96 @@ def test_a_h_shared_short_name_returns_unresolved_with_candidate_case() -> None:
     }
     assert cases[0].selected_entity_id is None
     assert cases[0].decision_type is DecisionType.MANUAL_REVIEW
+
+
+def test_existing_reference_id_updates_only_matching_unresolved_reference() -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+    existing = EntityReference(
+        reference_id="ref-existing",
+        raw_mention_text="贵州茅台",
+        source_context={"document_id": "doc-existing"},
+        resolved_entity_id=None,
+        resolution_method=ResolutionMethod.UNRESOLVED,
+        resolution_confidence=None,
+        created_at=datetime(2026, 4, 10, tzinfo=UTC),
+    )
+    reference_repo.save(existing)
+
+    result = resolve_mention_with_repositories(
+        "贵州茅台",
+        {"document_id": "doc-new"},
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        existing_reference_id="ref-existing",
+    )
+
+    updated = reference_repo.get("ref-existing")
+    assert result.resolved_entity_id == "ENT_STOCK_600519.SH"
+    assert updated is not None
+    assert updated.created_at == existing.created_at
+    assert updated.source_context == {"document_id": "doc-new"}
+    assert case_repo.find_by_reference("ref-existing")[0].selected_entity_id == (
+        "ENT_STOCK_600519.SH"
+    )
+
+
+@pytest.mark.parametrize(
+    ("existing_reference", "raw_mention_text", "match"),
+    [
+        (None, "贵州茅台", "not found"),
+        (
+            EntityReference(
+                reference_id="ref-existing",
+                raw_mention_text="其他公司",
+                source_context={},
+                resolved_entity_id=None,
+                resolution_method=ResolutionMethod.UNRESOLVED,
+                resolution_confidence=None,
+            ),
+            "贵州茅台",
+            "raw_mention_text mismatch",
+        ),
+        (
+            EntityReference(
+                reference_id="ref-existing",
+                raw_mention_text="贵州茅台",
+                source_context={},
+                resolved_entity_id="ENT_STOCK_600519.SH",
+                resolution_method=ResolutionMethod.DETERMINISTIC,
+                resolution_confidence=1.0,
+            ),
+            "贵州茅台",
+            "unresolved reference",
+        ),
+    ],
+)
+def test_existing_reference_id_rejects_invalid_update_targets(
+    existing_reference: EntityReference | None,
+    raw_mention_text: str,
+    match: str,
+) -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+    if existing_reference is not None:
+        reference_repo.save(existing_reference)
+
+    with pytest.raises(ValueError, match=match):
+        resolve_mention_with_repositories(
+            raw_mention_text,
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-existing",
+        )
+
+    assert case_repo.find_by_reference("ref-existing") == []
 
 
 def test_public_resolve_mention_uses_configured_default_repositories() -> None:


### PR DESCRIPTION
Closes #49

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/entity_registry/__init__.py`, `src/entity_registry/batch.py`


---
## P1 Backlog Cleanup (16 findings across 9 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (3 items)


- **L1** (conf=0.99, from PR #-25599): Generated artifacts are committed
  - Recommendation: Remove committed __pycache__ and *.egg-info files from the repository, keep the new .gitignore entries, and add a quick repository hygiene check if CI supports it.

- **L1** (conf=0.95, from PR #-8319): Generated Python artifacts are included in the milestone diff
  - Recommendation: Remove __pycache__ and generated egg-info files from version control, add them to .gitignore, and keep package metadata generated by the build backend rather than committed unless there is a deliberate release reason.

- **L1** (conf=0.9, from PR #-39293): Integration tests stop at helper boundaries
  - Recommendation: Add an end-to-end milestone test using one repository set: unresolved reference -> run_batch_resolution_job -> enqueue_batch_manual_review -> claim_review_item -> submit_manual_review_decision -> get_resolution_audit_payload, including both rejection and alias-promotion paths.

### `src/entity_registry/__init__.py` (1 items)


- **L220** (conf=0.84, from PR #47): Audit writer/case_repo mismatch can leave split audit records
  - Recommendation: Validate repository cohesion before public resolution writes, or replace the separate reference_repo/case_repo pair with one explicit audit unit-of-work that owns both writes and returns the persisted case used for contract conversion. Add a regression test with a mismatched native audit repository 

### `src/entity_registry/batch.py` (2 items)


- **L294** (conf=0.87, from PR #39): Per-item input error aborts before enqueuing already-persisted unresolved refere
  - Recommendation: Validate every effective source_reference_id, including IDs