### PR TITLE
feat(#49): P1 backlog cleanup (16 findings, 9 files)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "pydantic>=2.0",
-    "project-ult-contracts>=0.1.0",
+    "project-ult-contracts>=0.1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -168,6 +168,10 @@ def register_unresolved_reference(
             "registering unresolved references, or use "
             "configure_default_in_memory_audit_repositories() for tests/local workflows",
         )
+    _validate_public_resolution_audit_repository_cohesion(
+        repository_context.reference_repo,
+        repository_context.case_repo,
+    )
 
     unresolved_reference = _coerce_unresolved_reference(reference)
     case = _RuntimeResolutionCase(
@@ -216,6 +220,10 @@ def resolve_mention(
             "case_repo=...) before using public resolution APIs, or use "
             "configure_default_in_memory_audit_repositories() for tests/local workflows",
         )
+    _validate_public_resolution_audit_repository_cohesion(
+        repository_context.reference_repo,
+        repository_context.case_repo,
+    )
 
     reference_id = _new_public_reference_id()
     result = _runtime_resolve_mention_with_repositories(
@@ -260,8 +268,11 @@ def batch_resolve(
             "case_repo=...) before using public resolution APIs, or use "
             "configure_default_in_memory_audit_repositories() for tests/local workflows",
         )
-
     normalized_inputs = _public_batch_inputs_with_reference_ids(references)
+    _validate_public_resolution_audit_repository_cohesion(
+        repository_context.reference_repo,
+        repository_context.case_repo,
+    )
 
     def resolve_with_captured_context(
         raw_mention_text: str,
@@ -484,7 +495,7 @@ def _save_public_resolution_audit(
             "resolution audit writes require a native save_resolution(reference, case) "
             "unit of work; separate reference/case writes are not supported",
         )
-    _validate_resolution_audit_repository_cohesion(reference_repo, case_repo)
+    _validate_public_resolution_audit_repository_cohesion(reference_repo, case_repo)
 
     previous_reference = reference_repo.get(reference.reference_id)
     try:
@@ -509,6 +520,41 @@ def _save_public_resolution_audit(
             f"resolution case {case.case_id}",
         )
     return persisted_case
+
+
+def _validate_public_resolution_audit_repository_cohesion(
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+) -> None:
+    _validate_resolution_audit_repository_cohesion(reference_repo, case_repo)
+    save_resolution = getattr(reference_repo, "save_resolution", None)
+    save_new_resolution = getattr(reference_repo, "save_new_resolution", None)
+    if not callable(save_resolution) and not callable(save_new_resolution):
+        return
+
+    owned_case_repo = _public_owned_case_repository(reference_repo)
+    if owned_case_repo is case_repo:
+        return
+    if owned_case_repo is None:
+        raise ResolutionAuditRepositoryRequiredError(
+            "public resolution audit repositories must expose owned_case_repo() "
+            "matching the configured case_repo",
+        )
+    raise ResolutionAuditRepositoryRequiredError(
+        "reference_repo.save_resolution is bound to a different case repository",
+    )
+
+
+def _public_owned_case_repository(reference_repo: ReferenceRepository) -> object | None:
+    owned_case_repo = getattr(reference_repo, "owned_case_repo", None)
+    if callable(owned_case_repo):
+        return owned_case_repo()
+
+    for attribute in ("_case_repo", "case_repo"):
+        value = getattr(reference_repo, attribute, None)
+        if value is not None:
+            return value
+    return None
 
 
 def _restore_reference_after_audit_failure(

--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -108,6 +108,7 @@ from entity_registry.review import (
 from entity_registry.resolution import (
     DeterministicMatcher,
     ResolutionAuditRepositoryRequiredError,
+    _validate_resolution_audit_repository_cohesion,
     resolve_mention_with_repositories as _runtime_resolve_mention_with_repositories,
 )
 from entity_registry.resolution_types import (
@@ -227,7 +228,7 @@ def resolve_mention(
         fuzzy_matcher=repository_context.fuzzy_matcher,
         ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=reference_id,
+        new_reference_id=reference_id,
     )
     return _contract_case_for_reference(
         reference_id,
@@ -268,6 +269,10 @@ def batch_resolve(
         *,
         existing_reference_id: str | None = None,
     ) -> _RuntimeMentionResolutionResult:
+        reference_id_kwargs = _reference_id_kwargs_for_public_resolution(
+            existing_reference_id,
+            repository_context.reference_repo,
+        )
         return _runtime_resolve_mention_with_repositories(
             raw_mention_text,
             context,
@@ -278,7 +283,7 @@ def batch_resolve(
             fuzzy_matcher=repository_context.fuzzy_matcher,
             ner_extractor=repository_context.ner_extractor,
             reasoner_client=repository_context.reasoner_client,
-            existing_reference_id=existing_reference_id,
+            **reference_id_kwargs,
         )
 
     report = _runtime_run_batch_resolution_job(
@@ -375,6 +380,17 @@ def _coerce_public_batch_reference_input(
     raise TypeError("batch references must be EntityReference, dict, or str")
 
 
+def _reference_id_kwargs_for_public_resolution(
+    reference_id: str | None,
+    reference_repo: ReferenceRepository,
+) -> dict[str, str]:
+    if reference_id is None:
+        return {}
+    if reference_repo.get(reference_id) is None:
+        return {"new_reference_id": reference_id}
+    return {"existing_reference_id": reference_id}
+
+
 def _required_public_batch_text(
     payload: dict[str, object],
     field_name: str,
@@ -468,6 +484,7 @@ def _save_public_resolution_audit(
             "resolution audit writes require a native save_resolution(reference, case) "
             "unit of work; separate reference/case writes are not supported",
         )
+    _validate_resolution_audit_repository_cohesion(reference_repo, case_repo)
 
     previous_reference = reference_repo.get(reference.reference_id)
     try:

--- a/src/entity_registry/batch.py
+++ b/src/entity_registry/batch.py
@@ -202,6 +202,7 @@ def run_batch_resolution_job(
 
     active_resolver = resolver if resolver is not None else _resolve_mention_for_batch
     inputs = [_coerce_reference_input(reference) for reference in references]
+    _validate_effective_reference_ids(inputs)
     job.reference_ids = _unique_ids([
         item.source_reference_id
         for item in inputs
@@ -526,6 +527,10 @@ def _resolve_mention_for_batch(
         return resolve_mention(raw_mention_text, context)
 
     repository_context = _get_default_resolution_repository_context()
+    reference_id_kwargs = _reference_id_kwargs_for_resolution(
+        existing_reference_id,
+        repository_context.reference_repo,
+    )
     return resolve_mention_with_repositories(
         raw_mention_text,
         context,
@@ -533,11 +538,22 @@ def _resolve_mention_for_batch(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
-        existing_reference_id=existing_reference_id,
+        **reference_id_kwargs,
     )
+
+
+def _reference_id_kwargs_for_resolution(
+    reference_id: str | None,
+    reference_repo: ReferenceRepository,
+) -> dict[str, str]:
+    if reference_id is None:
+        return {}
+    if reference_repo.get(reference_id) is None:
+        return {"new_reference_id": reference_id}
+    return {"existing_reference_id": reference_id}
 
 
 def _resolver_accepts_existing_reference_id(resolver: Resolver) -> bool:

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -6,8 +6,6 @@ import hashlib
 from collections.abc import Sequence
 from typing import Any, Self
 
-import contracts.schemas as _contract_schemas
-import contracts.schemas.entities as _contract_entity_schemas
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
 from contracts.schemas import (
@@ -21,7 +19,7 @@ from contracts.schemas import (
 
 
 class ResolutionCase(_ContractResolutionCase):
-    """Contract resolution case with explicit no-candidate unresolved support."""
+    """Entity-registry boundary case with explicit no-candidate unresolved support."""
 
     candidate_entities: list[EntityReference]
 
@@ -32,15 +30,11 @@ class ResolutionCase(_ContractResolutionCase):
             and not self.candidate_entities
         ):
             raise ValueError(
-                "contracts ResolutionCase requires candidate_entities unless "
+                "entity-registry ResolutionCase requires candidate_entities unless "
                 "decision='unresolved'"
             )
         return self
 
-
-# Keep contract module imports aligned with the relaxed local boundary schema.
-_contract_schemas.ResolutionCase = ResolutionCase
-_contract_entity_schemas.ResolutionCase = ResolutionCase
 
 ContractCanonicalEntity = CanonicalEntity
 ContractEntityAlias = EntityAlias

--- a/src/entity_registry/contracts.py
+++ b/src/entity_registry/contracts.py
@@ -8,8 +8,8 @@ from typing import Any, Self
 
 from pydantic import model_validator
 from contracts.core import ContractBaseModel
+import contracts.schemas as _contract_schemas
 from contracts.schemas import (
-    CANONICAL_ID_RULE_VERSION,
     CanonicalEntity,
     EntityAlias,
     EntityReference,
@@ -17,9 +17,15 @@ from contracts.schemas import (
     ResolutionCase as _ContractResolutionCase,
 )
 
+CANONICAL_ID_RULE_VERSION = getattr(
+    _contract_schemas,
+    "CANONICAL_ID_RULE_VERSION",
+    "entity-registry-canonical-id-v1",
+)
+
 
 class ResolutionCase(_ContractResolutionCase):
-    """Entity-registry boundary case with explicit no-candidate unresolved support."""
+    """Entity-registry-owned case schema with no-candidate unresolved support."""
 
     candidate_entities: list[EntityReference]
 

--- a/src/entity_registry/core.py
+++ b/src/entity_registry/core.py
@@ -115,7 +115,6 @@ class CanonicalEntity(BaseModel):
     updated_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @model_validator(mode="after")
@@ -144,7 +143,6 @@ class EntityAlias(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow)
     canonical_id_rule_version: str = Field(
         default_factory=current_canonical_id_rule_version,
-        exclude=True,
     )
 
     @field_validator("confidence")

--- a/src/entity_registry/ner.py
+++ b/src/entity_registry/ner.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from entity_registry.resolution_types import ResolutionContext
 
 
+DEFAULT_HANLP_LITE_NER_MODEL = "MSRA_NER_ELECTRA_SMALL_ZH"
+
+
 class ExtractedMention(BaseModel):
     """One entity mention extracted from free text."""
 
@@ -125,10 +128,10 @@ class HanLPNERExtractor:
 def _default_hanlp_ner_model_name(hanlp: Any) -> str:
     pretrained = getattr(hanlp, "pretrained", None)
     ner_models = getattr(pretrained, "ner", None)
-    model_name = getattr(ner_models, "MSRA_NER_BERT_BASE_ZH", None)
+    model_name = getattr(ner_models, DEFAULT_HANLP_LITE_NER_MODEL, None)
     if isinstance(model_name, str):
         return model_name
-    return "MSRA_NER_BERT_BASE_ZH"
+    return DEFAULT_HANLP_LITE_NER_MODEL
 
 
 def _iter_ner_items(payload: Any, task_name: str | None) -> list[Any]:
@@ -251,6 +254,7 @@ def _optional_float(value: Any) -> float | None:
 
 
 __all__ = [
+    "DEFAULT_HANLP_LITE_NER_MODEL",
     "ExtractedMention",
     "HanLPNERExtractor",
     "NERExtractor",

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -59,6 +59,16 @@ class ResolutionAuditRepository(Protocol):
     ) -> None: ...
 
 
+class NewResolutionAuditRepository(ResolutionAuditRepository, Protocol):
+    """Audit repository that can atomically create a new reference."""
+
+    def save_new_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None: ...
+
+
 class ResolutionAuditRepositoryRequiredError(RuntimeError):
     """Raised when resolution is asked to write audit records without a UoW."""
 
@@ -92,6 +102,25 @@ class _RepositoryResolutionAuditRepository:
         raise ResolutionAuditRepositoryRequiredError(
             "resolution audit writes require a native save_resolution(reference, case) "
             "unit of work; separate reference/case writes are not supported",
+        )
+
+    def save_new_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None:
+        native_save_new_resolution = getattr(
+            self._reference_repo,
+            "save_new_resolution",
+            None,
+        )
+        if callable(native_save_new_resolution):
+            native_save_new_resolution(reference, case)
+            return
+
+        raise ResolutionAuditRepositoryRequiredError(
+            "new resolution audit writes require a native "
+            "save_new_resolution(reference, case) unit of work",
         )
 
 
@@ -415,7 +444,6 @@ def resolve_mention_with_repositories(
         raw_mention_text,
         reference_repo,
     )
-    _validate_new_reference_id(new_reference_id, reference_repo)
 
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(
@@ -470,6 +498,7 @@ def resolve_mention_with_repositories(
         audit_repo=audit_repo,
         reference_repo=reference_repo,
         case_repo=case_repo,
+        require_new_reference=new_reference_id is not None,
     )
     return MentionResolutionResult(
         raw_mention_text=raw_mention_text,
@@ -743,6 +772,7 @@ def _save_resolution_audit(
     audit_repo: ResolutionAuditRepository | None,
     reference_repo: ReferenceRepository | None,
     case_repo: ResolutionCaseRepository | None,
+    require_new_reference: bool = False,
 ) -> None:
     if audit_repo is None:
         if reference_repo is None or case_repo is None:
@@ -751,6 +781,15 @@ def _save_resolution_audit(
             )
         _validate_resolution_audit_repository_cohesion(reference_repo, case_repo)
         audit_repo = _RepositoryResolutionAuditRepository(reference_repo, case_repo)
+    if require_new_reference:
+        save_new_resolution = getattr(audit_repo, "save_new_resolution", None)
+        if not callable(save_new_resolution):
+            raise ResolutionAuditRepositoryRequiredError(
+                "new resolution audit writes require a native "
+                "save_new_resolution(reference, case) unit of work",
+            )
+        save_new_resolution(reference, case)
+        return
     audit_repo.save_resolution(reference, case)
 
 
@@ -780,16 +819,6 @@ def _existing_reference_for_update(
             "raw_mention_text",
         )
     return existing_reference
-
-
-def _validate_new_reference_id(
-    new_reference_id: str | None,
-    reference_repo: ReferenceRepository | None,
-) -> None:
-    if new_reference_id is None or reference_repo is None:
-        return
-    if reference_repo.get(new_reference_id) is not None:
-        raise ValueError(f"new_reference_id already exists: {new_reference_id}")
 
 
 def _validate_resolution_audit_repository_cohesion(
@@ -908,6 +937,7 @@ __all__ = [
     "DeterministicMatcher",
     "ResolutionAuditRepository",
     "ResolutionAuditRepositoryRequiredError",
+    "NewResolutionAuditRepository",
     "resolve_mention",
     "resolve_mention_with_repositories",
 ]

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -71,6 +71,7 @@ class _RepositoryResolutionAuditRepository:
         reference_repo: ReferenceRepository,
         case_repo: ResolutionCaseRepository,
     ) -> None:
+        _validate_resolution_audit_repository_cohesion(reference_repo, case_repo)
         self._reference_repo = reference_repo
         self._case_repo = case_repo
 
@@ -377,8 +378,8 @@ def resolve_mention(
         alias_repo=repository_context.alias_repo,
         reference_repo=repository_context.reference_repo,
         case_repo=repository_context.case_repo,
-        fuzzy_matcher=getattr(repository_context, "fuzzy_matcher", None),
-        ner_extractor=getattr(repository_context, "ner_extractor", None),
+        fuzzy_matcher=repository_context.fuzzy_matcher,
+        ner_extractor=repository_context.ner_extractor,
         reasoner_client=repository_context.reasoner_client,
     )
 
@@ -396,11 +397,25 @@ def resolve_mention_with_repositories(
     ner_extractor: NERExtractor | None = None,
     reasoner_client: ReasonerRuntimeClient | None = None,
     existing_reference_id: str | None = None,
+    new_reference_id: str | None = None,
 ) -> MentionResolutionResult:
     """Resolve one mention using explicit repositories and write audit records."""
 
     if existing_reference_id is not None and not existing_reference_id.strip():
         raise ValueError("existing_reference_id must be a non-empty string")
+    if new_reference_id is not None and not new_reference_id.strip():
+        raise ValueError("new_reference_id must be a non-empty string")
+    if existing_reference_id is not None and new_reference_id is not None:
+        raise ValueError(
+            "existing_reference_id and new_reference_id are mutually exclusive",
+        )
+
+    existing_reference = _existing_reference_for_update(
+        existing_reference_id,
+        raw_mention_text,
+        reference_repo,
+    )
+    _validate_new_reference_id(new_reference_id, reference_repo)
 
     matcher = DeterministicMatcher(entity_repo, alias_repo)
     candidate_set = matcher.collect_candidates_with_fuzzy(
@@ -427,13 +442,10 @@ def resolve_mention_with_repositories(
     resolution_confidence = decision.confidence if resolved_entity_id is not None else None
     candidate_entity_ids = _candidate_entity_ids(candidate_set)
 
-    existing_reference = (
-        reference_repo.get(existing_reference_id)
-        if existing_reference_id is not None and reference_repo is not None
-        else None
-    )
     reference_payload = {
-        "reference_id": existing_reference_id or _new_reference_id(),
+        "reference_id": (
+            existing_reference_id or new_reference_id or _new_reference_id()
+        ),
         "raw_mention_text": raw_mention_text,
         "source_context": source_context,
         "resolved_entity_id": resolved_entity_id,
@@ -737,8 +749,66 @@ def _save_resolution_audit(
             raise ResolutionAuditRepositoryRequiredError(
                 "resolution audit writes require audit_repo or reference_repo/case_repo"
             )
+        _validate_resolution_audit_repository_cohesion(reference_repo, case_repo)
         audit_repo = _RepositoryResolutionAuditRepository(reference_repo, case_repo)
     audit_repo.save_resolution(reference, case)
+
+
+def _existing_reference_for_update(
+    existing_reference_id: str | None,
+    raw_mention_text: str,
+    reference_repo: ReferenceRepository | None,
+) -> EntityReference | None:
+    if existing_reference_id is None:
+        return None
+    if reference_repo is None:
+        raise ValueError("existing_reference_id requires reference_repo")
+
+    existing_reference = reference_repo.get(existing_reference_id)
+    if existing_reference is None:
+        raise ValueError(f"existing_reference_id not found: {existing_reference_id}")
+    if (
+        existing_reference.resolved_entity_id is not None
+        or existing_reference.resolution_method is not ResolutionMethod.UNRESOLVED
+    ):
+        raise ValueError(
+            "existing_reference_id must refer to an unresolved reference",
+        )
+    if existing_reference.raw_mention_text != raw_mention_text:
+        raise ValueError(
+            "existing_reference_id raw_mention_text does not match the supplied "
+            "raw_mention_text",
+        )
+    return existing_reference
+
+
+def _validate_new_reference_id(
+    new_reference_id: str | None,
+    reference_repo: ReferenceRepository | None,
+) -> None:
+    if new_reference_id is None or reference_repo is None:
+        return
+    if reference_repo.get(new_reference_id) is not None:
+        raise ValueError(f"new_reference_id already exists: {new_reference_id}")
+
+
+def _validate_resolution_audit_repository_cohesion(
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+) -> None:
+    bound_case_repo = _bound_case_repository(reference_repo)
+    if bound_case_repo is not None and bound_case_repo is not case_repo:
+        raise ResolutionAuditRepositoryRequiredError(
+            "reference_repo.save_resolution is bound to a different case repository",
+        )
+
+
+def _bound_case_repository(reference_repo: ReferenceRepository) -> object | None:
+    for attribute in ("_case_repo", "case_repo"):
+        value = getattr(reference_repo, attribute, None)
+        if value is not None:
+            return value
+    return None
 
 
 def _generate_fuzzy_candidates(

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -833,6 +833,10 @@ def _validate_resolution_audit_repository_cohesion(
 
 
 def _bound_case_repository(reference_repo: ReferenceRepository) -> object | None:
+    owned_case_repo = getattr(reference_repo, "owned_case_repo", None)
+    if callable(owned_case_repo):
+        return owned_case_repo()
+
     for attribute in ("_case_repo", "case_repo"):
         value = getattr(reference_repo, attribute, None)
         if value is not None:

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -249,30 +249,49 @@ class InMemoryResolutionAuditReferenceRepository(InMemoryReferenceRepository):
         case: ResolutionCase,
     ) -> None:
         with self._lock:
-            if case.reference_id != reference.reference_id:
+            self._save_resolution_unchecked(reference, case)
+
+    def save_new_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None:
+        with self._lock:
+            if reference.reference_id in self._references:
                 raise ValueError(
-                    "resolution case reference_id must match EntityReference",
+                    f"new_reference_id already exists: {reference.reference_id}",
                 )
-            self._case_repo._validate_save(case)
-            reference_existed = reference.reference_id in self._references
-            previous_reference = self._references.get(reference.reference_id)
-            case_existed = case.case_id in self._case_repo._cases
-            previous_case = self._case_repo._cases.get(case.case_id)
+            self._save_resolution_unchecked(reference, case)
 
-            try:
-                self._save_unchecked(reference)
-                self._case_repo._save_unchecked(case)
-            except Exception:
-                if reference_existed and previous_reference is not None:
-                    self._references[reference.reference_id] = previous_reference
-                else:
-                    self._references.pop(reference.reference_id, None)
+    def _save_resolution_unchecked(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None:
+        if case.reference_id != reference.reference_id:
+            raise ValueError(
+                "resolution case reference_id must match EntityReference",
+            )
+        self._case_repo._validate_save(case)
+        reference_existed = reference.reference_id in self._references
+        previous_reference = self._references.get(reference.reference_id)
+        case_existed = case.case_id in self._case_repo._cases
+        previous_case = self._case_repo._cases.get(case.case_id)
 
-                if case_existed and previous_case is not None:
-                    self._case_repo._cases[case.case_id] = previous_case
-                else:
-                    self._case_repo._cases.pop(case.case_id, None)
-                raise
+        try:
+            self._save_unchecked(reference)
+            self._case_repo._save_unchecked(case)
+        except Exception:
+            if reference_existed and previous_reference is not None:
+                self._references[reference.reference_id] = previous_reference
+            else:
+                self._references.pop(reference.reference_id, None)
+
+            if case_existed and previous_case is not None:
+                self._case_repo._cases[case.case_id] = previous_case
+            else:
+                self._case_repo._cases.pop(case.case_id, None)
+            raise
 
 
 class InMemoryResolutionCaseRepository:

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -263,6 +263,11 @@ class InMemoryResolutionAuditReferenceRepository(InMemoryReferenceRepository):
                 )
             self._save_resolution_unchecked(reference, case)
 
+    def owned_case_repo(self) -> "InMemoryResolutionCaseRepository":
+        """Return the case repository owned by this audit unit of work."""
+
+        return self._case_repo
+
     def _save_resolution_unchecked(
         self,
         reference: EntityReference,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1083,6 +1083,13 @@ class FailingAuditReferenceRepository(InMemoryResolutionAuditReferenceRepository
     ) -> None:
         raise RuntimeError("audit failed")
 
+    def save_new_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None:
+        raise RuntimeError("audit failed")
+
 
 class FailingAfterSaveCountReviewRepository(InMemoryReviewRepository):
     def __init__(self, *, fail_after: int | None) -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -218,7 +218,13 @@ def test_cluster_unresolved_references_groups_by_normalized_mention_and_candidat
     ]
 
 
-def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id() -> None:
+@pytest.mark.parametrize(
+    "input_kind",
+    ["batch_reference_input", "entity_reference"],
+)
+def test_run_batch_resolution_job_rejects_duplicate_direct_reference_ids_before_running(
+    input_kind: str,
+) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
     def resolver(
@@ -229,34 +235,41 @@ def test_run_batch_resolution_job_delegates_and_dedupes_duplicate_reference_id()
         calls.append((raw_mention_text, context))
         return resolved_result(raw_mention_text)
 
-    job = BatchResolutionJob(job_id="job-dedupe", reference_ids=[], status="pending")
-    report = run_batch_resolution_job(
-        job,
-        [
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-            {
-                "reference_id": "ref-1",
-                "raw_mention_text": "贵州茅台",
-                "source_context": {"document_id": "doc-1"},
-            },
-        ],
-        resolver=resolver,
-    )
+    job = BatchResolutionJob(job_id="job-duplicate", reference_ids=[], status="pending")
+    if input_kind == "batch_reference_input":
+        references: list[BatchReferenceInput | EntityReference] = [
+            BatchReferenceInput(
+                raw_mention_text="贵州茅台",
+                source_context={"document_id": "doc-1"},
+                source_reference_id="ref-1",
+            ),
+            BatchReferenceInput(
+                raw_mention_text="贵州茅台",
+                source_context={"document_id": "doc-1"},
+                source_reference_id="ref-1",
+            ),
+        ]
+    else:
+        references = [
+            make_reference(
+                "ref-1",
+                "贵州茅台",
+                {"document_id": "doc-1"},
+            ),
+            make_reference(
+                "ref-1",
+                "贵州茅台",
+                {"document_id": "doc-1"},
+            ),
+        ]
 
-    assert calls == [("贵州茅台", {"document_id": "doc-1"})]
-    assert [outcome.result for outcome in report.outcomes] == [
-        resolved_result("贵州茅台"),
-        resolved_result("贵州茅台"),
-    ]
-    assert report.resolved_reference_ids == ["ref-1"]
-    assert report.job.reference_ids == ["ref-1"]
-    assert report.manual_review_reference_ids == []
-    assert report.job.status == "completed"
-    assert report.job.completed_at is not None
+    with pytest.raises(ValueError, match="duplicate source_reference_id"):
+        run_batch_resolution_job(job, references, resolver=resolver)
+
+    assert calls == []
+    assert job.status == "pending"
+    assert job.started_at is None
+    assert job.completed_at is None
 
 
 def test_run_batch_resolution_job_keeps_completed_outcomes_when_one_item_fails() -> None:
@@ -597,6 +610,134 @@ def test_batch_resolve_with_report_enqueues_review_items_and_supports_decisions(
     assert promoted_audit.entity_reference.resolution_method is ResolutionMethod.MANUAL
     assert promoted_audit.queue_item.status == "promoted"
     assert len(manual_aliases) == 1
+
+
+def test_unresolved_batch_review_audit_flow_rejects_and_promotes_aliases() -> None:
+    entity_repo, alias_repo = initialized_repositories()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+    review_repo = InMemoryReviewRepository()
+    fuzzy_matcher = RecordingFuzzyMatcher(
+        {
+            "宁德时代新能源": [
+                make_candidate(
+                    "ENT_STOCK_300750.SZ",
+                    score=0.91,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+                make_candidate(
+                    "ENT_STOCK_03750.HK",
+                    score=0.90,
+                    alias_text="宁德时代新能源科技股份有限公司",
+                ),
+            ],
+        }
+    )
+    reject_source = make_reference(
+        "ref-e2e-reject",
+        "未上市公司",
+        {"document_id": "doc-e2e", "path": "reject"},
+    )
+    promote_source = make_reference(
+        "ref-e2e-promote",
+        "宁德时代新能源",
+        {"document_id": "doc-e2e", "path": "promote"},
+    )
+    reference_repo.save(reject_source)
+    reference_repo.save(promote_source)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+    )
+
+    report = run_batch_resolution_job(
+        BatchResolutionJob(job_id="job-e2e", reference_ids=[], status="pending"),
+        collect_unresolved_references(reference_repo),
+    )
+    items = entity_registry.enqueue_batch_manual_review(
+        report,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+
+    assert {item.reference_id for item in items} == {
+        "ref-e2e-reject",
+        "ref-e2e-promote",
+    }
+    reject_item = review_repo.find_by_reference("ref-e2e-reject")
+    promote_item = review_repo.find_by_reference("ref-e2e-promote")
+    assert reject_item is not None
+    assert promote_item is not None
+
+    entity_registry.claim_review_item(
+        reject_item.queue_item_id,
+        "reviewer-a",
+        review_repo=review_repo,
+    )
+    entity_registry.submit_manual_review_decision(
+        reject_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id=None,
+            confidence=None,
+            rationale="not a listed entity",
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+    entity_registry.claim_review_item(
+        promote_item.queue_item_id,
+        "reviewer-b",
+        review_repo=review_repo,
+    )
+    entity_registry.submit_manual_review_decision(
+        promote_item.queue_item_id,
+        entity_registry.ManualReviewDecision(
+            selected_entity_id="ENT_STOCK_300750.SZ",
+            confidence=0.93,
+            rationale="manual reviewer selected the A-share listing",
+            promote_alias=True,
+            alias_type=AliasType.SHORT_NAME,
+        ),
+        review_repo=review_repo,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_writer=reference_repo,
+    )
+
+    rejected_audit = entity_registry.get_resolution_audit_payload(
+        "ref-e2e-reject",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_audit = entity_registry.get_resolution_audit_payload(
+        "ref-e2e-promote",
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        review_repo=review_repo,
+    )
+    promoted_aliases = [
+        alias
+        for alias in alias_repo.find_by_entity("ENT_STOCK_300750.SZ")
+        if alias.alias_text == "宁德时代新能源"
+        and alias.source == "manual_review"
+    ]
+
+    assert rejected_audit.entity_reference.resolved_entity_id is None
+    assert rejected_audit.entity_reference.resolution_method is (
+        ResolutionMethod.UNRESOLVED
+    )
+    assert rejected_audit.queue_item.status == "rejected"
+    assert promoted_audit.entity_reference.resolved_entity_id == "ENT_STOCK_300750.SZ"
+    assert promoted_audit.entity_reference.resolution_method is ResolutionMethod.MANUAL
+    assert promoted_audit.queue_item.status == "promoted"
+    assert len(promoted_aliases) == 1
 
 
 def test_batch_resolve_with_report_returns_report_when_review_enqueue_fails() -> None:

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -115,16 +115,16 @@ def test_entity_registry_reexports_contract_entity_schemas() -> None:
     assert registry_contracts.CanonicalEntity is contract_schemas.CanonicalEntity
     assert registry_contracts.EntityAlias is contract_schemas.EntityAlias
     assert registry_contracts.EntityReference is contract_schemas.EntityReference
-    assert registry_contracts.ResolutionCase is contract_schemas.ResolutionCase
+    assert registry_contracts.ResolutionCase is not contract_schemas.ResolutionCase
 
     assert entity_registry.CanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.EntityAlias is contract_schemas.EntityAlias
     assert entity_registry.EntityReference is contract_schemas.EntityReference
-    assert entity_registry.ResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ResolutionCase is registry_contracts.ResolutionCase
     assert entity_registry.ContractCanonicalEntity is contract_schemas.CanonicalEntity
     assert entity_registry.ContractEntityAlias is contract_schemas.EntityAlias
     assert entity_registry.ContractEntityReference is contract_schemas.EntityReference
-    assert entity_registry.ContractResolutionCase is contract_schemas.ResolutionCase
+    assert entity_registry.ContractResolutionCase is registry_contracts.ResolutionCase
     assert not hasattr(entity_registry, "CanonicalEntityProfile")
     assert not hasattr(entity_registry, "MentionResolutionResult")
 
@@ -154,14 +154,14 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
         "贵州茅台",
         {"source": "contract-boundary-test"},
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ContractResolutionCase.model_validate(
         resolution_case.model_dump(mode="json"),
     )
 
     batch_cases = entity_registry.batch_resolve(["平安银行", "不存在公司"])
     assert len(batch_cases) == 2
     for batch_case in batch_cases:
-        contract_schemas.ResolutionCase.model_validate(
+        registry_contracts.ContractResolutionCase.model_validate(
             batch_case.model_dump(mode="json"),
         )
 
@@ -172,7 +172,7 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
             "source_context": {"source": "contract-boundary-test"},
         }
     )
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ContractResolutionCase.model_validate(
         unresolved_case.model_dump(mode="json"),
     )
 
@@ -245,9 +245,40 @@ def test_root_batch_resolve_uses_one_repository_context_for_audit_conversion() -
     assert batch_cases[0].resolution_case_id == persisted_cases[0].case_id
     assert batch_cases[0].resolved_entity is not None
     assert batch_cases[0].resolved_entity.entity_id == "ENT_STOCK_000001.SZ"
-    contract_schemas.ResolutionCase.model_validate(
+    registry_contracts.ContractResolutionCase.model_validate(
         batch_cases[0].model_dump(mode="json"),
     )
+
+
+def test_root_resolve_rejects_mismatched_native_audit_repository_before_write() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    configured_case_repo = InMemoryResolutionCaseRepository()
+    bound_case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(bound_case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=configured_case_repo,
+    )
+
+    with pytest.raises(
+        entity_registry.ResolutionAuditRepositoryRequiredError,
+        match="different case repository",
+    ):
+        entity_registry.resolve_mention("贵州茅台", None)
+
+    assert reference_repo._references == {}
+    assert configured_case_repo._cases == {}
+    assert bound_case_repo._cases == {}
 
 
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
@@ -414,7 +445,7 @@ def test_no_candidate_unresolved_case_projects_to_contract_schema() -> None:
     assert dumped["candidate_entities"] == []
     assert "ENT_UNRESOLVED_NO_CANDIDATE" not in str(dumped)
 
-    reparsed = contract_schemas.ResolutionCase.model_validate(dumped)
+    reparsed = registry_contracts.ContractResolutionCase.model_validate(dumped)
     assert reparsed.candidate_entities == []
     assert reparsed.resolved_entity is None
 

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -555,3 +555,11 @@ class ReconfiguringAuditReferenceRepository(InMemoryResolutionAuditReferenceRepo
     ) -> None:
         super().save_resolution(reference, case)
         self._callback()
+
+    def save_new_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        super().save_new_resolution(reference, case)
+        self._callback()

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -4,6 +4,11 @@ import sys
 import tomllib
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
+from importlib.metadata import (
+    PackageNotFoundError,
+    distribution as package_distribution,
+    version as package_version,
+)
 from pathlib import Path
 
 import entity_registry
@@ -11,6 +16,7 @@ import entity_registry.contracts as registry_contracts
 import contracts.schemas as contract_schemas
 import pytest
 from contracts.core import __version__ as contracts_package_version
+from pydantic import ValidationError
 
 from entity_registry.core import (
     AliasType,
@@ -33,6 +39,7 @@ from entity_registry.resolution_types import MentionResolutionResult
 from entity_registry.storage import (
     InMemoryAliasRepository,
     InMemoryEntityRepository,
+    InMemoryReferenceRepository,
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
 )
@@ -40,6 +47,7 @@ from entity_registry.storage import (
 
 NOW = datetime(2026, 4, 15, tzinfo=UTC)
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS_SRC = PROJECT_ROOT.parent / "contracts" / "src"
 FIXTURE_PATH = PROJECT_ROOT / "tests" / "fixtures" / "stock_basic_sample.json"
 
 
@@ -53,6 +61,22 @@ def reset_public_repositories() -> Iterator[None]:
 def test_installed_contracts_dependency_exports_canonical_id_rule_version(
     tmp_path: Path,
 ) -> None:
+    try:
+        package_version("project-ult-contracts")
+        distribution_path = Path(
+            package_distribution("project-ult-contracts")._path,
+        ).resolve()
+    except PackageNotFoundError:
+        pytest.skip(
+            "project-ult-contracts is not installed; local tests use sibling "
+            "contracts/src fallback",
+        )
+    if distribution_path.is_relative_to(CONTRACTS_SRC.resolve()):
+        pytest.skip(
+            "project-ult-contracts metadata is from sibling contracts/src; "
+            "installed dependency check requires an importable package install",
+        )
+
     env = os.environ.copy()
     env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
     env["ENTITY_REGISTRY_CONTRACTS_SRC"] = str(
@@ -281,6 +305,68 @@ def test_root_resolve_rejects_mismatched_native_audit_repository_before_write() 
     assert bound_case_repo._cases == {}
 
 
+def test_resolve_mention_rejects_hidden_native_audit_repo() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    configured_case_repo = InMemoryResolutionCaseRepository()
+    hidden_case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = HiddenNativeAuditReferenceRepository(hidden_case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=configured_case_repo,
+    )
+
+    with pytest.raises(
+        entity_registry.ResolutionAuditRepositoryRequiredError,
+        match="different case repository",
+    ):
+        entity_registry.resolve_mention("贵州茅台", None)
+
+    assert reference_repo._references == {}
+    assert configured_case_repo._cases == {}
+    assert hidden_case_repo._cases == {}
+
+
+def test_batch_resolve_rejects_hidden_native_audit_repo_before_write() -> None:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    result = initialize_from_stock_basic_into(
+        str(FIXTURE_PATH),
+        entity_repo,
+        alias_repo,
+        stock_basic_reader=FileStockBasicSnapshotReader(),
+    )
+    assert result.errors == []
+    configured_case_repo = InMemoryResolutionCaseRepository()
+    hidden_case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = HiddenNativeAuditReferenceRepository(hidden_case_repo)
+    entity_registry.configure_default_repositories(
+        entity_repo,
+        alias_repo,
+        reference_repo=reference_repo,
+        case_repo=configured_case_repo,
+    )
+
+    with pytest.raises(
+        entity_registry.ResolutionAuditRepositoryRequiredError,
+        match="different case repository",
+    ):
+        entity_registry.batch_resolve(["贵州茅台"])
+
+    assert reference_repo._references == {}
+    assert configured_case_repo._cases == {}
+    assert hidden_case_repo._cases == {}
+
+
 def test_canonical_id_rule_version_tracks_entity_id_rule_not_package_release() -> None:
     entity = make_entity()
     alias = make_alias()
@@ -450,6 +536,67 @@ def test_no_candidate_unresolved_case_projects_to_contract_schema() -> None:
     assert reparsed.resolved_entity is None
 
 
+def test_resolution_case_shared_contract_compatibility_is_explicit() -> None:
+    entity = make_entity()
+    hk_entity = make_hk_entity()
+    matched_case = registry_contracts.to_contract_resolution_case(
+        make_case(),
+        input_alias="CATL",
+        candidate_entities=[entity],
+        decision=contract_schemas.EntityResolutionDecision.MATCHED,
+    )
+    ambiguous_case = registry_contracts.to_contract_resolution_case(
+        RuntimeResolutionCase(
+            case_id="case-ambiguous",
+            reference_id="ref-ambiguous",
+            candidate_entity_ids=[
+                "ENT_STOCK_03750.HK",
+                "ENT_STOCK_300750.SZ",
+            ],
+            selected_entity_id=None,
+            decision_type=DecisionType.MANUAL_REVIEW,
+            decision_rationale="ambiguous aliases",
+            created_at=NOW,
+        ),
+        input_alias="宁德时代",
+        candidate_entities=[hk_entity, entity],
+        decision=contract_schemas.EntityResolutionDecision.AMBIGUOUS,
+    )
+    no_candidate_case = registry_contracts.to_contract_resolution_case(
+        RuntimeResolutionCase(
+            case_id="case-no-candidate-shared",
+            reference_id="ref-no-candidate-shared",
+            candidate_entity_ids=[],
+            selected_entity_id=None,
+            decision_type=DecisionType.AUTO,
+            decision_rationale="no candidates found",
+            created_at=NOW,
+        ),
+        input_alias="不存在公司",
+        candidate_entities=[],
+        decision=contract_schemas.EntityResolutionDecision.UNRESOLVED,
+    )
+
+    contract_schemas.ResolutionCase.model_validate(
+        matched_case.model_dump(mode="json"),
+    )
+    contract_schemas.ResolutionCase.model_validate(
+        ambiguous_case.model_dump(mode="json"),
+    )
+
+    no_candidate_payload = no_candidate_case.model_dump(mode="json")
+    try:
+        contract_schemas.ResolutionCase.model_validate(no_candidate_payload)
+    except ValidationError:
+        registry_contracts.ContractResolutionCase.model_validate(no_candidate_payload)
+    else:
+        assert (
+            contract_schemas.ResolutionCase.model_validate(no_candidate_payload)
+            .candidate_entities
+            == []
+        )
+
+
 def test_mention_resolution_result_uses_stable_contract_shape() -> None:
     result = MentionResolutionResult(
         raw_mention_text="贵州茅台",
@@ -563,3 +710,37 @@ class ReconfiguringAuditReferenceRepository(InMemoryResolutionAuditReferenceRepo
     ) -> None:
         super().save_new_resolution(reference, case)
         self._callback()
+
+
+class HiddenNativeAuditReferenceRepository(InMemoryReferenceRepository):
+    def __init__(self, hidden_case_repo: InMemoryResolutionCaseRepository) -> None:
+        super().__init__()
+        self._hidden_case_repo = hidden_case_repo
+
+    def owned_case_repo(self) -> InMemoryResolutionCaseRepository:
+        return self._hidden_case_repo
+
+    def save_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        self.save(reference)
+        self._hidden_case_repo.save(case)
+
+    def save_new_resolution(
+        self,
+        reference: RuntimeEntityReference,
+        case: RuntimeResolutionCase,
+    ) -> None:
+        with self._lock:
+            if reference.reference_id in self._references:
+                raise ValueError(
+                    f"new_reference_id already exists: {reference.reference_id}",
+                )
+            self._save_unchecked(reference)
+            try:
+                self._hidden_case_repo.save(case)
+            except Exception:
+                self._references.pop(reference.reference_id, None)
+                raise

--- a/tests/test_contracts_alignment.py
+++ b/tests/test_contracts_alignment.py
@@ -58,6 +58,40 @@ def reset_public_repositories() -> Iterator[None]:
     entity_registry.reset_default_repositories()
 
 
+def _using_sibling_contracts_fallback() -> bool:
+    try:
+        distribution_path = Path(
+            package_distribution("project-ult-contracts")._path,
+        ).resolve()
+    except PackageNotFoundError:
+        return True
+    return distribution_path.is_relative_to(CONTRACTS_SRC.resolve())
+
+
+def _assert_no_candidate_unresolved_payload_schema(
+    payload: dict[str, object],
+) -> None:
+    assert (
+        payload["decision"]
+        == contract_schemas.EntityResolutionDecision.UNRESOLVED
+    )
+    assert payload["candidate_entities"] == []
+
+    try:
+        parsed = contract_schemas.ResolutionCase.model_validate(payload)
+    except ValidationError:
+        if not _using_sibling_contracts_fallback():
+            raise
+        parsed = registry_contracts.ContractResolutionCase.model_validate(payload)
+        assert registry_contracts.ResolutionCase is not contract_schemas.ResolutionCase
+        assert "Entity-registry-owned" in (
+            registry_contracts.ResolutionCase.__doc__ or ""
+        )
+
+    assert parsed.candidate_entities == []
+    assert parsed.resolved_entity is None
+
+
 def test_installed_contracts_dependency_exports_canonical_id_rule_version(
     tmp_path: Path,
 ) -> None:
@@ -178,16 +212,34 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
         "贵州茅台",
         {"source": "contract-boundary-test"},
     )
+    contract_schemas.ResolutionCase.model_validate(
+        resolution_case.model_dump(mode="json"),
+    )
     registry_contracts.ContractResolutionCase.model_validate(
         resolution_case.model_dump(mode="json"),
+    )
+
+    ambiguous_case = entity_registry.resolve_mention(
+        "宁德时代",
+        {"source": "contract-boundary-test"},
+    )
+    assert (
+        ambiguous_case.decision
+        is contract_schemas.EntityResolutionDecision.AMBIGUOUS
+    )
+    contract_schemas.ResolutionCase.model_validate(
+        ambiguous_case.model_dump(mode="json"),
     )
 
     batch_cases = entity_registry.batch_resolve(["平安银行", "不存在公司"])
     assert len(batch_cases) == 2
     for batch_case in batch_cases:
-        registry_contracts.ContractResolutionCase.model_validate(
-            batch_case.model_dump(mode="json"),
-        )
+        payload = batch_case.model_dump(mode="json")
+        registry_contracts.ContractResolutionCase.model_validate(payload)
+        if batch_case.candidate_entities:
+            contract_schemas.ResolutionCase.model_validate(payload)
+        else:
+            _assert_no_candidate_unresolved_payload_schema(payload)
 
     unresolved_case = entity_registry.register_unresolved_reference(
         {
@@ -196,7 +248,7 @@ def test_root_public_api_payloads_validate_against_contract_schemas() -> None:
             "source_context": {"source": "contract-boundary-test"},
         }
     )
-    registry_contracts.ContractResolutionCase.model_validate(
+    _assert_no_candidate_unresolved_payload_schema(
         unresolved_case.model_dump(mode="json"),
     )
 
@@ -584,17 +636,9 @@ def test_resolution_case_shared_contract_compatibility_is_explicit() -> None:
         ambiguous_case.model_dump(mode="json"),
     )
 
-    no_candidate_payload = no_candidate_case.model_dump(mode="json")
-    try:
-        contract_schemas.ResolutionCase.model_validate(no_candidate_payload)
-    except ValidationError:
-        registry_contracts.ContractResolutionCase.model_validate(no_candidate_payload)
-    else:
-        assert (
-            contract_schemas.ResolutionCase.model_validate(no_candidate_payload)
-            .candidate_entities
-            == []
-        )
+    _assert_no_candidate_unresolved_payload_schema(
+        no_candidate_case.model_dump(mode="json"),
+    )
 
 
 def test_mention_resolution_result_uses_stable_contract_shape() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,7 @@ def test_canonical_entity_builds_and_round_trips() -> None:
     assert restored == entity
     assert payload["canonical_entity_id"] == "ENT_STOCK_300750.SZ"
     assert payload["anchor_code"] == "300750.SZ"
+    assert payload["canonical_id_rule_version"] == entity.canonical_id_rule_version
 
 
 def test_stock_entity_requires_anchor_code() -> None:
@@ -134,6 +135,10 @@ def test_entity_alias_builds() -> None:
 
     assert alias.alias_type is AliasType.SHORT_NAME
     assert alias.confidence == 1.0
+    assert (
+        alias.model_dump(mode="json")["canonical_id_rule_version"]
+        == alias.canonical_id_rule_version
+    )
 
 
 @pytest.mark.parametrize("confidence", [-0.1, 1.1])

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -5,7 +5,12 @@ from pydantic import ValidationError
 
 import entity_registry
 import entity_registry.ner as ner_module
-from entity_registry.ner import ExtractedMention, HanLPNERExtractor, NullNERExtractor
+from entity_registry.ner import (
+    DEFAULT_HANLP_LITE_NER_MODEL,
+    ExtractedMention,
+    HanLPNERExtractor,
+    NullNERExtractor,
+)
 
 
 def test_package_exports_ner_public_types() -> None:
@@ -78,3 +83,29 @@ def test_hanlp_extractor_normalizes_fake_hanlp_payload(
     assert mentions[0].entity_type == "ORG"
     assert mentions[0].confidence == 0.93
     assert mentions[1].start == 5
+
+
+def test_hanlp_default_model_selects_lite_pretrained_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_models: list[str] = []
+    lite_model_name = "hanlp-lite-msra-ner"
+
+    def load(model_name: str):
+        loaded_models.append(model_name)
+        return lambda text: []
+
+    fake_hanlp = SimpleNamespace(
+        load=load,
+        pretrained=SimpleNamespace(
+            ner=SimpleNamespace(**{DEFAULT_HANLP_LITE_NER_MODEL: lite_model_name}),
+        ),
+    )
+    monkeypatch.setattr(
+        ner_module.importlib,
+        "import_module",
+        lambda name: fake_hanlp,
+    )
+
+    assert HanLPNERExtractor().extract_mentions("贵州茅台公告") == []
+    assert loaded_models == [lite_model_name]

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -1,4 +1,5 @@
 import inspect
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -297,6 +298,53 @@ def test_existing_reference_id_rejects_raw_mention_mismatch_before_overwrite() -
     assert case_repo.find_by_reference("ref-mismatch") == []
 
 
+def test_concurrent_new_reference_id_conflict_writes_one_audit_case() -> None:
+    entity_repo, alias_repo, _reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+    reference_repo = BlockingNewResolutionAuditReferenceRepository(case_repo, parties=2)
+    results: list[MentionResolutionResult] = []
+    errors: list[BaseException] = []
+
+    def resolve(raw_mention_text: str) -> None:
+        try:
+            results.append(
+                resolve_mention_with_repositories(
+                    raw_mention_text,
+                    None,
+                    entity_repo=entity_repo,
+                    alias_repo=alias_repo,
+                    reference_repo=reference_repo,
+                    case_repo=case_repo,
+                    new_reference_id="ref-concurrent",
+                ),
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=resolve, args=("不存在的公司 A",)),
+        threading.Thread(target=resolve, args=("不存在的公司 B",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=3)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert "new_reference_id already exists" in str(errors[0])
+
+    reference = reference_repo.get("ref-concurrent")
+    cases = case_repo.find_by_reference("ref-concurrent")
+    assert reference is not None
+    assert reference.raw_mention_text in {"不存在的公司 A", "不存在的公司 B"}
+    assert len(cases) == 1
+    assert cases[0].reference_id == "ref-concurrent"
+
+
 def test_a_h_shared_short_name_returns_unresolved_with_candidate_case() -> None:
     entity_repo, alias_repo, reference_repo, case_repo = (
         initialized_resolution_repositories()
@@ -514,3 +562,43 @@ class NativeResolutionAuditReferenceRepository(InMemoryReferenceRepository):
         if self.case_repo is not None:
             self.case_repo.save(case)
         self.saved_cases.append(case)
+
+    def save_new_resolution(
+        self,
+        reference: EntityReference,
+        case: entity_registry.ResolutionCase,
+    ) -> None:
+        with self._lock:
+            if reference.reference_id in self._references:
+                raise ValueError(
+                    f"new_reference_id already exists: {reference.reference_id}",
+                )
+            self._save_unchecked(reference)
+            try:
+                if self.case_repo is not None:
+                    self.case_repo.save(case)
+                self.saved_cases.append(case)
+            except Exception:
+                self._references.pop(reference.reference_id, None)
+                raise
+
+
+class BlockingNewResolutionAuditReferenceRepository(
+    NativeResolutionAuditReferenceRepository,
+):
+    def __init__(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+        *,
+        parties: int,
+    ) -> None:
+        super().__init__(case_repo)
+        self._barrier = threading.Barrier(parties)
+
+    def save_new_resolution(
+        self,
+        reference: EntityReference,
+        case: entity_registry.ResolutionCase,
+    ) -> None:
+        self._barrier.wait(timeout=2)
+        super().save_new_resolution(reference, case)

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -219,6 +219,84 @@ def test_missing_mention_returns_unresolved_and_writes_audit_records() -> None:
     assert cases[0].selected_entity_id is None
 
 
+def test_existing_reference_id_rejects_missing_reference_before_write() -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+
+    with pytest.raises(ValueError, match="existing_reference_id not found"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-missing",
+        )
+
+    assert reference_repo.get("ref-missing") is None
+    assert case_repo.find_by_reference("ref-missing") == []
+
+
+def test_existing_reference_id_rejects_resolved_reference_before_overwrite() -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+    existing_reference = EntityReference(
+        reference_id="ref-resolved",
+        raw_mention_text="贵州茅台",
+        source_context={"document_id": "doc-original"},
+        resolved_entity_id="ENT_STOCK_600519.SH",
+        resolution_method=ResolutionMethod.DETERMINISTIC,
+        resolution_confidence=1.0,
+    )
+    reference_repo.save(existing_reference)
+
+    with pytest.raises(ValueError, match="unresolved reference"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            {"document_id": "doc-new"},
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-resolved",
+        )
+
+    assert reference_repo.get("ref-resolved") == existing_reference
+    assert case_repo.find_by_reference("ref-resolved") == []
+
+
+def test_existing_reference_id_rejects_raw_mention_mismatch_before_overwrite() -> None:
+    entity_repo, alias_repo, reference_repo, case_repo = (
+        initialized_resolution_repositories()
+    )
+    existing_reference = EntityReference(
+        reference_id="ref-mismatch",
+        raw_mention_text="原始公司",
+        source_context={"document_id": "doc-original"},
+        resolved_entity_id=None,
+        resolution_method=ResolutionMethod.UNRESOLVED,
+        resolution_confidence=None,
+    )
+    reference_repo.save(existing_reference)
+
+    with pytest.raises(ValueError, match="raw_mention_text"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            {"document_id": "doc-new"},
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-mismatch",
+        )
+
+    assert reference_repo.get("ref-mismatch") == existing_reference
+    assert case_repo.find_by_reference("ref-mismatch") == []
+
+
 def test_a_h_shared_short_name_returns_unresolved_with_candidate_case() -> None:
     entity_repo, alias_repo, reference_repo, case_repo = (
         initialized_resolution_repositories()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -323,6 +323,21 @@ def test_in_memory_resolution_audit_reference_repository_saves_reference_and_cas
     assert case_repo.get("case-1") == case
 
 
+def test_in_memory_resolution_audit_reference_repository_rejects_new_reference_conflict() -> None:
+    case_repo = InMemoryResolutionCaseRepository()
+    repository = InMemoryResolutionAuditReferenceRepository(case_repo)
+    existing_reference = make_reference("ref-1", None)
+    new_reference = make_reference("ref-1", "ENT_STOCK_300750.SZ")
+    case = make_case("case-1", "ref-1", "ENT_STOCK_300750.SZ")
+    repository.save(existing_reference)
+
+    with pytest.raises(ValueError, match="new_reference_id already exists"):
+        repository.save_new_resolution(new_reference, case)
+
+    assert repository.get("ref-1") == existing_reference
+    assert case_repo.find_by_reference("ref-1") == []
+
+
 def test_in_memory_resolution_audit_repository_stages_case_before_reference() -> None:
     case_repo = FailingResolutionCaseRepository()
     repository = InMemoryResolutionAuditReferenceRepository(case_repo)


### PR DESCRIPTION
Closes #49

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`


---
## P1 Backlog Cleanup (16 findings across 9 files)

Consolidated cleanup of P1 findings accumulated from milestone reviews. 
These are non-blocking improvements identified during code review.

**Fix all (or as many as feasible) in a single PR.** Items are grouped by file:


### `cross-cutting` (3 items)


- **L1** (conf=0.99, from PR #-25599): Generated artifacts are committed
  - Recommendation: Remove committed __pycache__ and *.egg-info files from the repository, keep the new .gitignore entries, and add a quick repository hygiene check if CI supports it.

- **L1** (conf=0.95, from PR #-8319): Generated Python artifacts are included in the milestone diff
  - Recommendation: Remove __pycache__ and generated egg-info files from version control, add them to .gitignore, and keep package metadata generated by the build backend rather than committed unless there is a deliberate release reason.

- **L1** (conf=0.9, from PR #-39293): Integration tests stop at helper boundaries
  - Recommendation: Add an end-to-end milestone test using one repository set: unresolved reference -> run_batch_resolution_job -> enqueue_batch_manual_review -> claim_review_item -> submit_manual_review_decision -> get_resolution_audit_payload, including both rejection and alias-promotion paths.

### `src/entity_registry/__init__.py` (1 items)


- **L220** (conf=0.84, from PR #47): Audit writer/case_repo mismatch can leave split audit records
  - Recommendation: Validate repository cohesion before public resolution writes, or replace the separate reference_repo/case_repo pair with one explicit audit unit-of-work that owns both writes and returns the persisted case used for contract conversion. Add a regression test with a mismatched native audit repository 

### `src/entity_registry/batch.py` (2 items)


- **L294** (conf=0.87, from PR #39): Per-item input error aborts before enqueuing already-persisted unresolved refere
  - Recommendation: Validate every effective source_reference_id, including IDs