### PR TITLE
feat(#55): [milestone-99 review] P0: Audit cohesion depends on private repository internals

### DIFF
--- a/src/entity_registry/__init__.py
+++ b/src/entity_registry/__init__.py
@@ -122,6 +122,8 @@ from entity_registry.storage import (
     InMemoryReviewRepository,
     InMemoryResolutionCaseRepository,
     ReferenceRepository,
+    ResolutionAuditReferenceRepository,
+    ResolutionAuditRepository,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -541,6 +543,8 @@ __all__ = [
     "NullFuzzyMatcher",
     "NullNERExtractor",
     "ReasonerRuntimeClient",
+    "ResolutionAuditReferenceRepository",
+    "ResolutionAuditRepository",
     "RepositoryNotConfiguredError",
     "ResolutionAuditPayload",
     "ResolutionCase",

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import cast
+from collections.abc import Callable
+from typing import cast, overload
 
 from entity_registry.aliases import AliasManager, normalize_alias_text
 from entity_registry.core import (
@@ -345,6 +346,60 @@ def resolve_mention(
     )
 
 
+@overload
+def resolve_mention_with_repositories(
+    raw_mention_text: str,
+    context: ResolutionContext | dict[str, object] | None,
+    *,
+    entity_repo: EntityRepository,
+    alias_repo: AliasRepository,
+    audit_repo: ReadableResolutionAuditRepository,
+    reference_repo: ReferenceRepository | None = ...,
+    case_repo: ResolutionCaseRepository | None = ...,
+    fuzzy_matcher: FuzzyMatcher | None = ...,
+    ner_extractor: NERExtractor | None = ...,
+    reasoner_client: ReasonerRuntimeClient | None = ...,
+    existing_reference_id: str,
+    allow_new_reference_id: bool = ...,
+) -> MentionResolutionResult: ...
+
+
+@overload
+def resolve_mention_with_repositories(
+    raw_mention_text: str,
+    context: ResolutionContext | dict[str, object] | None,
+    *,
+    entity_repo: EntityRepository,
+    alias_repo: AliasRepository,
+    audit_repo: None = ...,
+    reference_repo: ReferenceRepository,
+    case_repo: ResolutionCaseRepository,
+    fuzzy_matcher: FuzzyMatcher | None = ...,
+    ner_extractor: NERExtractor | None = ...,
+    reasoner_client: ReasonerRuntimeClient | None = ...,
+    existing_reference_id: str,
+    allow_new_reference_id: bool = ...,
+) -> MentionResolutionResult: ...
+
+
+@overload
+def resolve_mention_with_repositories(
+    raw_mention_text: str,
+    context: ResolutionContext | dict[str, object] | None,
+    *,
+    entity_repo: EntityRepository,
+    alias_repo: AliasRepository,
+    audit_repo: ResolutionAuditRepository | None = ...,
+    reference_repo: ReferenceRepository | None = ...,
+    case_repo: ResolutionCaseRepository | None = ...,
+    fuzzy_matcher: FuzzyMatcher | None = ...,
+    ner_extractor: NERExtractor | None = ...,
+    reasoner_client: ReasonerRuntimeClient | None = ...,
+    existing_reference_id: None = ...,
+    allow_new_reference_id: bool = ...,
+) -> MentionResolutionResult: ...
+
+
 def resolve_mention_with_repositories(
     raw_mention_text: str,
     context: ResolutionContext | dict[str, object] | None,
@@ -363,8 +418,10 @@ def resolve_mention_with_repositories(
     """Resolve one mention using explicit repositories and write audit records.
 
     When ``existing_reference_id`` is provided, validation reads from the same
-    audit boundary that will receive ``save_resolution``: ``audit_repo`` when
-    supplied, otherwise ``reference_repo``.
+    audit boundary that will receive ``save_resolution``. Supplying
+    ``audit_repo`` for that path requires ``ReadableResolutionAuditRepository``;
+    otherwise the read comes from ``ReferenceRepository`` before the public
+    case-repository ownership preflight and before any mutation.
     """
 
     if existing_reference_id is not None and not existing_reference_id.strip():
@@ -799,7 +856,7 @@ def _validate_existing_reference_for_update(
 def _reference_reader_for_update(
     reference_repo: ReferenceRepository | None,
     audit_repo: ResolutionAuditRepository | None,
-):
+) -> Callable[[str], EntityReference | None] | None:
     if audit_repo is not None:
         get_reference = getattr(audit_repo, "get", None)
         if callable(get_reference):
@@ -907,6 +964,7 @@ def _source_context_from(
 
 __all__ = [
     "DeterministicMatcher",
+    "ReadableResolutionAuditRepository",
     "ResolutionAuditRepository",
     "ResolutionAuditRepositoryRequiredError",
     "resolve_mention",

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -40,6 +40,7 @@ from entity_registry.resolution_types import (
 from entity_registry.storage import (
     AliasRepository,
     EntityRepository,
+    ReadableResolutionAuditRepository,
     ReferenceRepository,
     ResolutionAuditReferenceRepository,
     ResolutionAuditRepository,
@@ -359,7 +360,12 @@ def resolve_mention_with_repositories(
     existing_reference_id: str | None = None,
     allow_new_reference_id: bool = False,
 ) -> MentionResolutionResult:
-    """Resolve one mention using explicit repositories and write audit records."""
+    """Resolve one mention using explicit repositories and write audit records.
+
+    When ``existing_reference_id`` is provided, validation reads from the same
+    audit boundary that will receive ``save_resolution``: ``audit_repo`` when
+    supplied, otherwise ``reference_repo``.
+    """
 
     if existing_reference_id is not None and not existing_reference_id.strip():
         raise ValueError("existing_reference_id must be a non-empty string")
@@ -713,16 +719,6 @@ def _save_resolution_audit(
     )
     audit_reference_repo.save_resolution(reference, case)
 
-    # Cohesion guard: native save_resolution adapters must persist the case
-    # into the configured case_repo. Mirrors _save_public_resolution_audit so
-    # PUBLIC and runtime resolution share the same audit invariants.
-    if case_repo.get(case.case_id) is None:
-        raise ResolutionAuditRepositoryRequiredError(
-            "resolution audit repository did not persist the resolution case "
-            f"{case.case_id} into the configured case_repo; save_resolution must "
-            "write to the same case_repo passed to resolve_mention_with_repositories",
-        )
-
 
 def _validate_repository_audit_cohesion(
     reference_repo: ReferenceRepository,
@@ -730,8 +726,8 @@ def _validate_repository_audit_cohesion(
 ) -> ResolutionAuditReferenceRepository:
     """Return the public audit UoW, rejecting split write repositories.
 
-    Cohesion is verified by saving through ``save_resolution`` and then reading
-    the case back through the supplied ``case_repo``. The guard intentionally
+    Cohesion is verified before mutation through the public
+    ``owns_resolution_case_repository`` preflight. The guard intentionally
     avoids inspecting adapter internals or requiring object identity with a
     private case repository attribute.
     """
@@ -741,6 +737,19 @@ def _validate_repository_audit_cohesion(
         raise ResolutionAuditRepositoryRequiredError(
             "resolution audit writes require a native save_resolution(reference, case) "
             "unit of work; separate reference/case writes are not supported",
+        )
+
+    owns_case_repo = getattr(reference_repo, "owns_resolution_case_repository", None)
+    if not callable(owns_case_repo):
+        raise ResolutionAuditRepositoryRequiredError(
+            "resolution audit writes require a native "
+            "owns_resolution_case_repository(case_repo) cohesion preflight",
+        )
+    if not owns_case_repo(case_repo):
+        raise ResolutionAuditRepositoryRequiredError(
+            "resolution audit repository does not own the configured case_repo; "
+            "save_resolution must write to the same case_repo passed to "
+            "resolve_mention_with_repositories",
         )
     return cast(ResolutionAuditReferenceRepository, reference_repo)
 
@@ -759,8 +768,9 @@ def _validate_existing_reference_for_update(
     get_reference = _reference_reader_for_update(reference_repo, audit_repo)
     if get_reference is None:
         raise ResolutionAuditRepositoryRequiredError(
-            "existing_reference_id requires a readable reference repository or "
-            "audit_repo.get(reference_id) before resolution writes",
+            "existing_reference_id requires the audit write boundary to expose "
+            "get(reference_id): audit_repo.get(...) when audit_repo is provided, "
+            "otherwise reference_repo.get(...)",
         )
 
     existing_reference = get_reference(existing_reference_id)
@@ -790,15 +800,15 @@ def _reference_reader_for_update(
     reference_repo: ReferenceRepository | None,
     audit_repo: ResolutionAuditRepository | None,
 ):
+    if audit_repo is not None:
+        get_reference = getattr(audit_repo, "get", None)
+        if callable(get_reference):
+            return cast(ReadableResolutionAuditRepository, audit_repo).get
+        return None
+
     if reference_repo is not None:
         return reference_repo.get
 
-    if audit_repo is None:
-        return None
-
-    get_reference = getattr(audit_repo, "get", None)
-    if callable(get_reference):
-        return get_reference
     return None
 
 

--- a/src/entity_registry/resolution.py
+++ b/src/entity_registry/resolution.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Protocol
+from typing import cast
 
 from entity_registry.aliases import AliasManager, normalize_alias_text
 from entity_registry.core import (
@@ -41,58 +41,18 @@ from entity_registry.storage import (
     AliasRepository,
     EntityRepository,
     ReferenceRepository,
+    ResolutionAuditReferenceRepository,
+    ResolutionAuditRepository,
     ResolutionCaseRepository,
 )
 
 
 _LOGGER = logging.getLogger(__name__)
 _LLM_CONFIDENCE_THRESHOLD = 0.80
-_MISSING_CASE_REPO_OWNER = object()
-
-
-class ResolutionAuditRepository(Protocol):
-    """Unit-of-work contract for writing resolution audit records."""
-
-    def save_resolution(
-        self,
-        reference: EntityReference,
-        case: ResolutionCase,
-    ) -> None: ...
 
 
 class ResolutionAuditRepositoryRequiredError(RuntimeError):
     """Raised when resolution is asked to write audit records without a UoW."""
-
-
-class _RepositoryResolutionAuditRepository:
-    """Resolution audit unit of work over native repository contracts."""
-
-    def __init__(
-        self,
-        reference_repo: ReferenceRepository,
-        case_repo: ResolutionCaseRepository,
-    ) -> None:
-        self._reference_repo = reference_repo
-        self._case_repo = case_repo
-
-    def save_resolution(
-        self,
-        reference: EntityReference,
-        case: ResolutionCase,
-    ) -> None:
-        native_save_resolution = getattr(
-            self._reference_repo,
-            "save_resolution",
-            None,
-        )
-        if callable(native_save_resolution):
-            native_save_resolution(reference, case)
-            return
-
-        raise ResolutionAuditRepositoryRequiredError(
-            "resolution audit writes require a native save_resolution(reference, case) "
-            "unit of work; separate reference/case writes are not supported",
-        )
 
 
 class DeterministicMatcher:
@@ -407,6 +367,7 @@ def resolve_mention_with_repositories(
         existing_reference_id,
         raw_mention_text,
         reference_repo,
+        audit_repo=audit_repo,
         allow_new_reference_id=allow_new_reference_id,
     )
 
@@ -746,16 +707,11 @@ def _save_resolution_audit(
             "resolution audit writes require audit_repo or reference_repo/case_repo"
         )
 
-    native_save_resolution = getattr(reference_repo, "save_resolution", None)
-    if not callable(native_save_resolution):
-        raise ResolutionAuditRepositoryRequiredError(
-            "resolution audit writes require a native save_resolution(reference, case) "
-            "unit of work; separate reference/case writes are not supported",
-        )
-
-    _validate_repository_audit_cohesion(reference_repo, case_repo)
-    repository_audit = _RepositoryResolutionAuditRepository(reference_repo, case_repo)
-    repository_audit.save_resolution(reference, case)
+    audit_reference_repo = _validate_repository_audit_cohesion(
+        reference_repo,
+        case_repo,
+    )
+    audit_reference_repo.save_resolution(reference, case)
 
     # Cohesion guard: native save_resolution adapters must persist the case
     # into the configured case_repo. Mirrors _save_public_resolution_audit so
@@ -771,31 +727,22 @@ def _save_resolution_audit(
 def _validate_repository_audit_cohesion(
     reference_repo: ReferenceRepository,
     case_repo: ResolutionCaseRepository,
-) -> None:
-    owned_case_repo = _owned_case_repo(reference_repo)
-    if owned_case_repo is _MISSING_CASE_REPO_OWNER:
-        raise ResolutionAuditRepositoryRequiredError(
-            "resolution audit repository must expose owned_case_repo() returning "
-            "the configured case_repo before resolution writes",
-        )
-    if owned_case_repo is not case_repo:
-        raise ResolutionAuditRepositoryRequiredError(
-            "resolution audit repository owns a different case_repo than the "
-            "case_repo passed to resolve_mention_with_repositories",
-        )
+) -> ResolutionAuditReferenceRepository:
+    """Return the public audit UoW, rejecting split write repositories.
 
+    Cohesion is verified by saving through ``save_resolution`` and then reading
+    the case back through the supplied ``case_repo``. The guard intentionally
+    avoids inspecting adapter internals or requiring object identity with a
+    private case repository attribute.
+    """
 
-def _owned_case_repo(
-    reference_repo: ReferenceRepository,
-) -> ResolutionCaseRepository | object:
-    owned_case_repo = getattr(reference_repo, "owned_case_repo", None)
-    if callable(owned_case_repo):
-        return owned_case_repo()
-    if hasattr(reference_repo, "_case_repo"):
-        return getattr(reference_repo, "_case_repo")
-    if hasattr(reference_repo, "case_repo"):
-        return getattr(reference_repo, "case_repo")
-    return _MISSING_CASE_REPO_OWNER
+    save_resolution = getattr(reference_repo, "save_resolution", None)
+    if not callable(save_resolution):
+        raise ResolutionAuditRepositoryRequiredError(
+            "resolution audit writes require a native save_resolution(reference, case) "
+            "unit of work; separate reference/case writes are not supported",
+        )
+    return cast(ResolutionAuditReferenceRepository, reference_repo)
 
 
 def _validate_existing_reference_for_update(
@@ -803,12 +750,20 @@ def _validate_existing_reference_for_update(
     raw_mention_text: str,
     reference_repo: ReferenceRepository | None,
     *,
+    audit_repo: ResolutionAuditRepository | None = None,
     allow_new_reference_id: bool = False,
 ) -> EntityReference | None:
-    if existing_reference_id is None or reference_repo is None:
+    if existing_reference_id is None:
         return None
 
-    existing_reference = reference_repo.get(existing_reference_id)
+    get_reference = _reference_reader_for_update(reference_repo, audit_repo)
+    if get_reference is None:
+        raise ResolutionAuditRepositoryRequiredError(
+            "existing_reference_id requires a readable reference repository or "
+            "audit_repo.get(reference_id) before resolution writes",
+        )
+
+    existing_reference = get_reference(existing_reference_id)
     if existing_reference is None:
         if allow_new_reference_id:
             return None
@@ -829,6 +784,22 @@ def _validate_existing_reference_for_update(
             "existing_reference_id must refer to an unresolved reference",
         )
     return existing_reference
+
+
+def _reference_reader_for_update(
+    reference_repo: ReferenceRepository | None,
+    audit_repo: ResolutionAuditRepository | None,
+):
+    if reference_repo is not None:
+        return reference_repo.get
+
+    if audit_repo is None:
+        return None
+
+    get_reference = getattr(audit_repo, "get", None)
+    if callable(get_reference):
+        return get_reference
+    return None
 
 
 def _generate_fuzzy_candidates(

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -62,6 +62,31 @@ class ReferenceRepository(Protocol):
     def find_unresolved(self) -> list[EntityReference]: ...
 
 
+class ResolutionAuditRepository(Protocol):
+    """Unit-of-work contract for atomic resolution audit writes.
+
+    Implementations must persist the reference and its resolution case together.
+    When a caller also supplies a ``ResolutionCaseRepository`` for audit
+    readback, the saved case must be visible through that repository.
+    """
+
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None: ...
+
+
+class ResolutionAuditReferenceRepository(ReferenceRepository, Protocol):
+    """Reference repository that also owns resolution audit writes."""
+
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: ResolutionCase,
+    ) -> None: ...
+
+
 class ResolutionCaseRepository(Protocol):
     """Storage contract for resolution audit cases."""
 

--- a/src/entity_registry/storage.py
+++ b/src/entity_registry/storage.py
@@ -66,8 +66,10 @@ class ResolutionAuditRepository(Protocol):
     """Unit-of-work contract for atomic resolution audit writes.
 
     Implementations must persist the reference and its resolution case together.
-    When a caller also supplies a ``ResolutionCaseRepository`` for audit
-    readback, the saved case must be visible through that repository.
+    ``save_resolution`` is the only mutation boundary. Existing-reference
+    updates that need pre-write validation should use
+    ``ReadableResolutionAuditRepository`` so the read and write use the same
+    unit of work.
     """
 
     def save_resolution(
@@ -77,14 +79,31 @@ class ResolutionAuditRepository(Protocol):
     ) -> None: ...
 
 
+class ReadableResolutionAuditRepository(ResolutionAuditRepository, Protocol):
+    """Resolution audit unit of work that can read references it owns."""
+
+    def get(self, reference_id: str) -> EntityReference | None: ...
+
+
 class ResolutionAuditReferenceRepository(ReferenceRepository, Protocol):
-    """Reference repository that also owns resolution audit writes."""
+    """Reference repository that also owns resolution audit writes.
+
+    ``owns_resolution_case_repository`` is a non-mutating cohesion preflight.
+    It must return true only when ``save_resolution(reference, case)`` will
+    persist the case through the supplied case repository in the same atomic
+    audit unit of work.
+    """
 
     def save_resolution(
         self,
         reference: EntityReference,
         case: ResolutionCase,
     ) -> None: ...
+
+    def owns_resolution_case_repository(
+        self,
+        case_repo: "ResolutionCaseRepository",
+    ) -> bool: ...
 
 
 class ResolutionCaseRepository(Protocol):
@@ -298,6 +317,12 @@ class InMemoryResolutionAuditReferenceRepository(InMemoryReferenceRepository):
                 else:
                     self._case_repo._cases.pop(case.case_id, None)
                 raise
+
+    def owns_resolution_case_repository(
+        self,
+        case_repo: "ResolutionCaseRepository",
+    ) -> bool:
+        return case_repo is self._case_repo
 
 
 class InMemoryResolutionCaseRepository:

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -366,6 +366,28 @@ def test_resolution_audit_uses_native_save_resolution_boundary() -> None:
     assert reference_repo.saved_cases[0].reference_id == references[0].reference_id
 
 
+def test_resolution_audit_accepts_public_uow_without_case_repo_attrs() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = PublicContractAuditReferenceRepository(CaseAuditBackend(case_repo))
+
+    result = resolve_mention_with_repositories(
+        "贵州茅台",
+        None,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+    )
+
+    references = saved_references(reference_repo)
+    assert result.resolved_entity_id == "ENT_STOCK_600519.SH"
+    assert len(references) == 1
+    assert len(case_repo.find_by_reference(references[0].reference_id)) == 1
+
+
 def test_existing_reference_id_must_exist_before_resolution_write() -> None:
     entity_repo, alias_repo, _reference_repo, _case_repo = (
         initialized_resolution_repositories()
@@ -442,6 +464,53 @@ def test_existing_reference_id_must_match_raw_mention_before_resolution_write() 
     assert case_repo.find_by_reference("ref-mismatch") == []
 
 
+def test_existing_reference_id_with_audit_repo_only_requires_reader() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    audit_repo = WriteOnlyAuditRepository()
+
+    with pytest.raises(
+        ResolutionAuditRepositoryRequiredError,
+        match="existing_reference_id requires",
+    ):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            audit_repo=audit_repo,
+            existing_reference_id="ref-unreadable",
+        )
+
+    assert audit_repo.references == []
+    assert audit_repo.cases == []
+
+
+def test_existing_reference_id_with_audit_repo_only_uses_reader() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    audit_repo = ReadableAuditRepository()
+    existing = make_reference("ref-readable", "贵州茅台")
+    audit_repo.references_by_id[existing.reference_id] = existing
+
+    result = resolve_mention_with_repositories(
+        "贵州茅台",
+        None,
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        audit_repo=audit_repo,
+        existing_reference_id=existing.reference_id,
+    )
+
+    assert result.resolved_entity_id == "ENT_STOCK_600519.SH"
+    assert audit_repo.references_by_id["ref-readable"].resolved_entity_id == (
+        "ENT_STOCK_600519.SH"
+    )
+    assert audit_repo.cases[0].reference_id == "ref-readable"
+
+
 def test_resolution_module_has_no_provider_or_later_stage_imports() -> None:
     text = Path("src/entity_registry/resolution.py").read_text(encoding="utf-8")
 
@@ -449,13 +518,7 @@ def test_resolution_module_has_no_provider_or_later_stage_imports() -> None:
         assert forbidden not in text
 
 
-def test_runtime_resolve_rejects_hidden_native_audit_repo_before_save() -> None:
-    """Cohesion check: native save_resolution must expose its case_repo.
-
-    Mirrors the cohesion guard in the public ``_save_public_resolution_audit``
-    path so PUBLIC and runtime resolution share the same audit invariants.
-    """
-
+def test_runtime_resolve_rejects_audit_repo_that_hides_case_write() -> None:
     entity_repo, alias_repo, _reference_repo, _case_repo = (
         initialized_resolution_repositories()
     )
@@ -464,7 +527,7 @@ def test_runtime_resolve_rejects_hidden_native_audit_repo_before_save() -> None:
 
     with pytest.raises(
         ResolutionAuditRepositoryRequiredError,
-        match="must expose owned_case_repo",
+        match="did not persist the resolution case",
     ):
         resolve_mention_with_repositories(
             "贵州茅台",
@@ -475,8 +538,6 @@ def test_runtime_resolve_rejects_hidden_native_audit_repo_before_save() -> None:
             case_repo=case_repo,
         )
 
-    # Hidden native audit repositories are rejected before any write.
-    assert saved_references(reference_repo) == []
     assert case_repo.find_by_reference("any") == []
 
 
@@ -612,11 +673,64 @@ class NativeResolutionAuditReferenceRepository(InMemoryReferenceRepository):
         self.saved_cases.append(case)
 
 
+class PublicContractAuditReferenceRepository(InMemoryReferenceRepository):
+    def __init__(self, audit_backend: "CaseAuditBackend") -> None:
+        super().__init__()
+        self.audit_backend = audit_backend
+
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: entity_registry.ResolutionCase,
+    ) -> None:
+        self.save(reference)
+        self.audit_backend.save_case(case)
+
+
+class CaseAuditBackend:
+    def __init__(self, case_repo: InMemoryResolutionCaseRepository) -> None:
+        self._target = case_repo
+
+    def save_case(self, case: entity_registry.ResolutionCase) -> None:
+        self._target.save(case)
+
+
+class WriteOnlyAuditRepository:
+    def __init__(self) -> None:
+        self.references: list[EntityReference] = []
+        self.cases: list[entity_registry.ResolutionCase] = []
+
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: entity_registry.ResolutionCase,
+    ) -> None:
+        self.references.append(reference)
+        self.cases.append(case)
+
+
+class ReadableAuditRepository:
+    def __init__(self) -> None:
+        self.references_by_id: dict[str, EntityReference] = {}
+        self.cases: list[entity_registry.ResolutionCase] = []
+
+    def get(self, reference_id: str) -> EntityReference | None:
+        return self.references_by_id.get(reference_id)
+
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: entity_registry.ResolutionCase,
+    ) -> None:
+        self.references_by_id[reference.reference_id] = reference
+        self.cases.append(case)
+
+
 class ReferenceOnlyAuditReferenceRepository(InMemoryReferenceRepository):
     """Native save_resolution that writes the reference but skips the case_repo.
 
-    This adapter passes the ``save_resolution`` method check but hides the case
-    repository owner, so the runtime cohesion guard must reject it before save.
+    This adapter passes the ``save_resolution`` method check, but the case
+    readback guard rejects it because it never persists the resolution case.
     """
 
     def save_resolution(

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -346,8 +346,6 @@ def test_resolution_audit_uses_native_save_resolution_boundary() -> None:
         initialized_resolution_repositories()
     )
     case_repo = InMemoryResolutionCaseRepository()
-    # Native save_resolution must persist into the configured case_repo so the
-    # runtime cohesion guard in _save_resolution_audit accepts the unit of work.
     reference_repo = NativeResolutionAuditReferenceRepository(case_repo=case_repo)
 
     result = resolve_mention_with_repositories(
@@ -511,6 +509,33 @@ def test_existing_reference_id_with_audit_repo_only_uses_reader() -> None:
     assert audit_repo.cases[0].reference_id == "ref-readable"
 
 
+def test_existing_reference_id_reads_from_audit_write_boundary() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = NativeResolutionAuditReferenceRepository(case_repo=case_repo)
+    reference_repo_reference = make_reference("ref-shared-reader", "贵州茅台")
+    reference_repo.save(reference_repo_reference)
+    audit_repo = ReadableAuditRepository()
+
+    with pytest.raises(ValueError, match="was not found"):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            audit_repo=audit_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+            existing_reference_id="ref-shared-reader",
+        )
+
+    assert reference_repo.get("ref-shared-reader") == reference_repo_reference
+    assert audit_repo.references_by_id == {}
+    assert audit_repo.cases == []
+
+
 def test_resolution_module_has_no_provider_or_later_stage_imports() -> None:
     text = Path("src/entity_registry/resolution.py").read_text(encoding="utf-8")
 
@@ -524,10 +549,12 @@ def test_runtime_resolve_rejects_audit_repo_that_hides_case_write() -> None:
     )
     reference_repo = ReferenceOnlyAuditReferenceRepository()
     case_repo = InMemoryResolutionCaseRepository()
+    original = make_reference("ref-orphan-risk", "贵州茅台")
+    reference_repo.save(original)
 
     with pytest.raises(
         ResolutionAuditRepositoryRequiredError,
-        match="did not persist the resolution case",
+        match="does not own the configured case_repo",
     ):
         resolve_mention_with_repositories(
             "贵州茅台",
@@ -536,9 +563,11 @@ def test_runtime_resolve_rejects_audit_repo_that_hides_case_write() -> None:
             alias_repo=alias_repo,
             reference_repo=reference_repo,
             case_repo=case_repo,
+            existing_reference_id=original.reference_id,
         )
 
-    assert case_repo.find_by_reference("any") == []
+    assert reference_repo.get(original.reference_id) == original
+    assert case_repo.find_by_reference(original.reference_id) == []
 
 
 def test_audit_failure_does_not_restore_over_interleaved_successful_resolution() -> None:
@@ -672,6 +701,12 @@ class NativeResolutionAuditReferenceRepository(InMemoryReferenceRepository):
             self.case_repo.save(case)
         self.saved_cases.append(case)
 
+    def owns_resolution_case_repository(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+    ) -> bool:
+        return case_repo is self.case_repo
+
 
 class PublicContractAuditReferenceRepository(InMemoryReferenceRepository):
     def __init__(self, audit_backend: "CaseAuditBackend") -> None:
@@ -686,6 +721,12 @@ class PublicContractAuditReferenceRepository(InMemoryReferenceRepository):
         self.save(reference)
         self.audit_backend.save_case(case)
 
+    def owns_resolution_case_repository(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+    ) -> bool:
+        return self.audit_backend.owns_resolution_case_repository(case_repo)
+
 
 class CaseAuditBackend:
     def __init__(self, case_repo: InMemoryResolutionCaseRepository) -> None:
@@ -693,6 +734,12 @@ class CaseAuditBackend:
 
     def save_case(self, case: entity_registry.ResolutionCase) -> None:
         self._target.save(case)
+
+    def owns_resolution_case_repository(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+    ) -> bool:
+        return case_repo is self._target
 
 
 class WriteOnlyAuditRepository:
@@ -740,6 +787,12 @@ class ReferenceOnlyAuditReferenceRepository(InMemoryReferenceRepository):
     ) -> None:
         self.save(reference)
         # Intentionally do not write ``case`` anywhere.
+
+    def owns_resolution_case_repository(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+    ) -> bool:
+        return False
 
 
 class InterleavingFailingAuditReferenceRepository(

--- a/tests/test_resolution_resolve_mention.py
+++ b/tests/test_resolution_resolve_mention.py
@@ -570,6 +570,31 @@ def test_runtime_resolve_rejects_audit_repo_that_hides_case_write() -> None:
     assert case_repo.find_by_reference(original.reference_id) == []
 
 
+def test_audit_cohesion_preflight_runs_before_save_resolution() -> None:
+    entity_repo, alias_repo, _reference_repo, _case_repo = (
+        initialized_resolution_repositories()
+    )
+    reference_repo = MutatingCohesionRejectingAuditReferenceRepository()
+    case_repo = InMemoryResolutionCaseRepository()
+
+    with pytest.raises(
+        ResolutionAuditRepositoryRequiredError,
+        match="does not own the configured case_repo",
+    ):
+        resolve_mention_with_repositories(
+            "贵州茅台",
+            None,
+            entity_repo=entity_repo,
+            alias_repo=alias_repo,
+            reference_repo=reference_repo,
+            case_repo=case_repo,
+        )
+
+    assert reference_repo.save_resolution_calls == 0
+    assert saved_references(reference_repo) == []
+    assert case_repo.find_by_reference("any") == []
+
+
 def test_audit_failure_does_not_restore_over_interleaved_successful_resolution() -> None:
     entity_repo, alias_repo, _reference_repo, _case_repo = (
         initialized_resolution_repositories()
@@ -787,6 +812,26 @@ class ReferenceOnlyAuditReferenceRepository(InMemoryReferenceRepository):
     ) -> None:
         self.save(reference)
         # Intentionally do not write ``case`` anywhere.
+
+    def owns_resolution_case_repository(
+        self,
+        case_repo: InMemoryResolutionCaseRepository,
+    ) -> bool:
+        return False
+
+
+class MutatingCohesionRejectingAuditReferenceRepository(InMemoryReferenceRepository):
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_resolution_calls = 0
+
+    def save_resolution(
+        self,
+        reference: EntityReference,
+        case: entity_registry.ResolutionCase,
+    ) -> None:
+        self.save_resolution_calls += 1
+        self.save(reference)
 
     def owns_resolution_case_repository(
         self,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -30,6 +30,7 @@ from entity_registry.storage import (
     InMemoryResolutionAuditReferenceRepository,
     InMemoryResolutionCaseRepository,
     ReferenceRepository,
+    ResolutionAuditReferenceRepository,
     ReviewRepository,
     ResolutionCaseRepository,
 )
@@ -314,6 +315,20 @@ def test_in_memory_reference_repository_upserts_by_reference_id() -> None:
 def test_in_memory_resolution_audit_reference_repository_saves_reference_and_case() -> None:
     case_repo = InMemoryResolutionCaseRepository()
     repository = InMemoryResolutionAuditReferenceRepository(case_repo)
+    reference = make_reference("ref-1", "ENT_STOCK_300750.SZ")
+    case = make_case("case-1", "ref-1", "ENT_STOCK_300750.SZ")
+
+    repository.save_resolution(reference, case)
+
+    assert repository.get("ref-1") == reference
+    assert case_repo.get("case-1") == case
+
+
+def test_resolution_audit_reference_repository_protocol_is_usable_for_in_memory() -> None:
+    case_repo = InMemoryResolutionCaseRepository()
+    repository: ResolutionAuditReferenceRepository = (
+        InMemoryResolutionAuditReferenceRepository(case_repo)
+    )
     reference = make_reference("ref-1", "ENT_STOCK_300750.SZ")
     case = make_case("case-1", "ref-1", "ENT_STOCK_300750.SZ")
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -336,6 +336,11 @@ def test_resolution_audit_reference_repository_protocol_is_usable_for_in_memory(
 
     assert repository.get("ref-1") == reference
     assert case_repo.get("case-1") == case
+    assert repository.owns_resolution_case_repository(case_repo) is True
+    assert (
+        repository.owns_resolution_case_repository(InMemoryResolutionCaseRepository())
+        is False
+    )
 
 
 def test_in_memory_resolution_audit_repository_stages_case_before_reference() -> None:


### PR DESCRIPTION
Closes #55

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/entity_registry/resolution.py`


---
## 背景与目标
Milestone review for milestone-99 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The new cohesion guard infers the case repository owner from `owned_case_repo()`, `_case_repo`, or `case_repo` on the reference repository, but that requirement is not part of `ReferenceRepository` or `ResolutionAuditRepository`. This couples resolution to in-memory implementation details and object identity. A legitimate transactional PostgreSQL or Iceberg-backed audit adapter could implement atomic `save_resolution(reference, case)` correctly and still be rejected because it does not expose a case repository object with one of these private names.

## 实现范围
- 修改文件: `src/entity_registry/resolution.py`
- Promote the audit unit-of-work contract into an explicit public protocol, for example `ResolutionAuditReferenceRepository` with `save_resolution()` and a documented owner/cohesion check, or make a single audit repository object the only write boundary. Update storage protocols, in-memory repositories, and tests to use that explicit contract instead of private attribute introspection.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/entity-registry/.venv/bin/python -m pytest
```
