### PR TITLE
[codex] Pin shared fixtures v0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,11 @@ contracts-schemas = [
     "project-ult-contracts @ git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3",
 ]
 # Shared regression fixtures (iron rule #6).
+# Pinned to v0.2.5 (bumped 2026-05-01 stage 1 consistency lane to align
+# all 10 consumers with the audit-eval producer release; carries forward
+# v0.2.4 dot-form canonical_entity_id reconciliation).
 shared-fixtures = [
-    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@v0.2.4",
+    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@v0.2.5",
 ]
 ner = [
     "hanlp>=2.1",


### PR DESCRIPTION
## Summary
- pin `shared-fixtures` to `project-ult-audit-eval@v0.2.5`
- document the stage 1 consistency-lane reason for the pin

## Scope
- pin-only `pyproject.toml` update
- no entity schema, API, matching, or runtime behavior changes

## Validation
- `.venv/bin/python -m pytest -q`
- `git diff --check origin/main...HEAD`
