### PR TITLE
[codex] Add M4.8 focused resolution proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,43 @@
 # entity-registry
 
-This module is scaffold-only.
+Canonical entity ID and alias resolution for project-ult. The package now has
+runtime implementation for ENT_* canonical entities, alias storage, deterministic
+mention resolution, fuzzy candidate injection, LLM-assisted disambiguation
+boundaries, reference audit records, resolution cases, batch workflows, and
+manual-review audit payloads.
 
 Source of truth:
 
 - `docs/entity-registry.project-doc.md`
+- shared schemas from `contracts`
 
 Current workspace state:
 
-- `docs/` keeps the source project doc
-- `pyproject.toml` is placeholder project metadata
-- implementation directories are created only when real work starts
+- `src/entity_registry/` contains the implementation.
+- `tests/` covers deterministic resolution, fuzzy candidate behavior, LLM
+  boundaries, references, contracts alignment, and red-line boundary checks.
+- `scripts/m4_8_focused_resolution_proof.py` is a focused proof harness for the
+  existing resolution chain.
+
+## M4.8 Focused Resolution Proof
+
+The M4.8 proof harness verifies the existing `resolve_mention_with_repositories`
+path with in-memory repositories. It covers deterministic exact/code/rule hits,
+ambiguous injected fuzzy candidates that are not auto-selected, unresolved
+fail-closed behavior, runtime `ResolutionCase` records, review audit payloads,
+and contracts projection.
+
+Run it with:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src python scripts/m4_8_focused_resolution_proof.py
+```
+
+This is focused evidence, not productionization of the fuzzy backend. The proof
+injects a fake fuzzy matcher and does not add core resolver capability.
 
 Execution rule:
 
 1. read the project doc first
 2. keep work inside this module unless the issue explicitly targets shared contracts
-3. do not treat this scaffold as finished implementation
+3. do not change shared contracts from this repository

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,28 +1,49 @@
 # entity-registry 项目进度总览
 
-> 最后更新：2026-04-17
+> 最后更新：2026-05-07
 
 ## 里程碑概览
 
 | 阶段 | 里程碑 | Issues | 状态 | 退出条件 |
 |------|--------|--------|------|----------|
-| 阶段 0 | P1 最小实体锚点 | ISSUE-001, ISSUE-002 | 🔲 未开始 | 全部 A 股上市公司有正式 canonical_entity_id |
-| 阶段 1 | P1-P2 确定性解析 | ISSUE-003, ISSUE-004 | 🔲 未开始 | 主系统和图谱能稳定读取 ENT_* 锚点 |
-| 阶段 2 | P4 模糊解析与 LLM 辅助 | ISSUE-005, ISSUE-006 | 🔲 未开始 | 复杂新闻/公告 mention 能进入完整解析链 |
-| 阶段 3 | P4-P5 批量回补与人工复核 | ISSUE-007, ISSUE-008 | 🔲 未开始 | 未解析引用不再静默堆积 |
+| 阶段 0 | P1 最小实体锚点 | ISSUE-001, ISSUE-002 | ✅ 已实现 | 全部 A 股上市公司有正式 canonical_entity_id |
+| 阶段 1 | P1-P2 确定性解析 | ISSUE-003, ISSUE-004 | ✅ 已实现 | 主系统和图谱能稳定读取 ENT_* 锚点 |
+| 阶段 2 | P4 模糊解析与 LLM 辅助 | ISSUE-005, ISSUE-006 | 🟨 已实现基础链路，待生产化 | 复杂新闻/公告 mention 能进入完整解析链 |
+| 阶段 3 | P4-P5 批量回补与人工复核 | ISSUE-007, ISSUE-008 | 🟨 已实现内存工作流，待持久化生产化 | 未解析引用不再静默堆积 |
 
 ## Issue 详细状态
 
 | Issue | 标题 | 优先级 | 里程碑 | 依赖 | 状态 |
 |-------|------|--------|--------|------|------|
-| ISSUE-001 | 项目基础设施与核心领域对象模型 | P0 | milestone-0 | 无 | 🔲 未开始 |
-| ISSUE-002 | stock_basic 初始化管线与别名生成 | P0 | milestone-0 | #001 | 🔲 未开始 |
-| ISSUE-003 | 别名查表与确定性匹配引擎 | P1 | milestone-1 | #002 | 🔲 未开始 |
-| ISSUE-004 | 实体画像查询与 resolve_mention 确定性路径 | P1 | milestone-1 | #003 | 🔲 未开始 |
-| ISSUE-005 | HanLP NER 集成与 Splink 模糊候选生成 | P2 | milestone-2 | #004 | 🔲 未开始 |
-| ISSUE-006 | reasoner-runtime LLM 辅助消歧与完整解析链 | P2 | milestone-2 | #005 | 🔲 未开始 |
-| ISSUE-007 | 批量解析与未解析引用回补 | P2 | milestone-3 | #006 | 🔲 未开始 |
-| ISSUE-008 | 人工复核队列与解析审计链 | P2 | milestone-3 | #007 | 🔲 未开始 |
+| ISSUE-001 | 项目基础设施与核心领域对象模型 | P0 | milestone-0 | 无 | ✅ 已实现 |
+| ISSUE-002 | stock_basic 初始化管线与别名生成 | P0 | milestone-0 | #001 | ✅ 已实现 |
+| ISSUE-003 | 别名查表与确定性匹配引擎 | P1 | milestone-1 | #002 | ✅ 已实现 |
+| ISSUE-004 | 实体画像查询与 resolve_mention 确定性路径 | P1 | milestone-1 | #003 | ✅ 已实现 |
+| ISSUE-005 | HanLP NER 集成与模糊候选接口 | P2 | milestone-2 | #004 | 🟨 基础链路已实现，外部后端待生产化 |
+| ISSUE-006 | reasoner-runtime LLM 辅助消歧与完整解析链 | P2 | milestone-2 | #005 | 🟨 边界与注入链路已实现，运行时接入待生产化 |
+| ISSUE-007 | 批量解析与未解析引用回补 | P2 | milestone-3 | #006 | 🟨 内存工作流已实现，持久化适配待生产化 |
+| ISSUE-008 | 人工复核队列与解析审计链 | P2 | milestone-3 | #007 | 🟨 内存工作流与审计 payload 已实现，持久化适配待生产化 |
+
+## M4.8 focused proof
+
+状态：✅ 已覆盖 focused proof，待生产化扩展。
+
+本轮新增 `scripts/m4_8_focused_resolution_proof.py`，复用现有
+`resolve_mention_with_repositories()` 解析链和 in-memory repositories，验证：
+
+- deterministic exact/code/rule 命中
+- ambiguous injected fuzzy candidates 不自动乱选，进入 manual review 语义
+- no-candidate unresolved fail-closed
+- runtime `ResolutionCase`
+- `get_resolution_audit_payload()` 审计 payload
+- contracts `ResolutionCase` projection
+
+边界声明：
+
+- 不修改 contracts。
+- 不新增 holdings subtype。
+- 不新增核心 resolver 能力。
+- proof 使用 injected fake fuzzy matcher；外部 fuzzy 后端生产化仍待后续工作。
 
 ## 依赖链
 
@@ -31,7 +52,7 @@ ISSUE-001 (核心模型)
   └── ISSUE-002 (stock_basic 初始化)
         └── ISSUE-003 (确定性匹配)
               └── ISSUE-004 (画像查询 + resolve_mention 确定性)
-                    └── ISSUE-005 (HanLP + Splink 模糊)
+                    └── ISSUE-005 (HanLP + fuzzy 候选接口)
                           └── ISSUE-006 (LLM 辅助消歧)
                                 └── ISSUE-007 (批量回补)
                                       └── ISSUE-008 (人工复核)

--- a/docs/evidence/m4-8-focused-resolution-proof-20260507.md
+++ b/docs/evidence/m4-8-focused-resolution-proof-20260507.md
@@ -1,0 +1,45 @@
+# M4.8 Focused Resolution Proof Evidence
+
+Date: 2026-05-07
+
+## Scope
+
+M4.8 adds a focused proof harness around the existing entity-registry resolution
+chain. The harness uses in-memory repositories, `resolve_mention_with_repositories`,
+runtime `ResolutionCase` records, `get_resolution_audit_payload`, and contracts
+projection helpers.
+
+Covered proof cases:
+
+- deterministic exact alias hit
+- deterministic code alias hit
+- deterministic rule hit from suffixed stock code
+- ambiguous injected fuzzy candidates that remain unresolved and require review
+- no-candidate unresolved path that fails closed
+
+## Non-goals
+
+- No contracts package changes.
+- No holdings subtype.
+- No new core resolver capability.
+- No claim that the placeholder fuzzy adapter is production-ready.
+
+## Verification
+
+Primary commands:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src python -m pytest -q -p no:cacheprovider \
+  tests/test_resolution_deterministic.py \
+  tests/test_resolution_fuzzy.py \
+  tests/test_resolution_resolve_mention.py \
+  tests/test_resolution_llm.py \
+  tests/test_references.py \
+  tests/test_contracts_alignment.py \
+  tests/boundary \
+  tests/proof/test_m4_8_focused_resolution_proof.py
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src python scripts/m4_8_focused_resolution_proof.py
+python -m py_compile scripts/m4_8_focused_resolution_proof.py
+git diff --check origin/main...HEAD
+git diff --check
+```

--- a/scripts/m4_8_focused_resolution_proof.py
+++ b/scripts/m4_8_focused_resolution_proof.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python
+"""M4.8 focused proof for entity-registry mention resolution.
+
+The proof uses the existing in-memory repositories and resolution chain. It
+injects a tiny fake fuzzy matcher so the harness can verify fuzzy candidate
+handling without depending on an external matcher backend.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from entity_registry.contracts import (
+    EntityResolutionDecision,
+    to_contract_resolution_case,
+)
+from entity_registry.core import (
+    AliasType,
+    CanonicalEntity,
+    DecisionType,
+    EntityAlias,
+    EntityStatus,
+    EntityType,
+    ResolutionMethod,
+)
+from entity_registry.fuzzy import FuzzyCandidate
+from entity_registry.references import EntityReference, ResolutionCase
+from entity_registry.resolution import resolve_mention_with_repositories
+from entity_registry.review import get_resolution_audit_payload
+from entity_registry.storage import (
+    InMemoryAliasRepository,
+    InMemoryEntityRepository,
+    InMemoryResolutionAuditReferenceRepository,
+    InMemoryResolutionCaseRepository,
+)
+
+
+@dataclass(frozen=True)
+class ProofFixture:
+    entity_repo: InMemoryEntityRepository
+    alias_repo: InMemoryAliasRepository
+    reference_repo: InMemoryResolutionAuditReferenceRepository
+    case_repo: InMemoryResolutionCaseRepository
+    fuzzy_matcher: "InjectedFakeFuzzyMatcher"
+
+
+class InjectedFakeFuzzyMatcher:
+    """Static fuzzy matcher used only by this proof harness."""
+
+    auto_resolve_score = 0.96
+
+    def __init__(self, candidates_by_mention: dict[str, list[FuzzyCandidate]]) -> None:
+        self._candidates_by_mention = candidates_by_mention
+        self.calls: list[str] = []
+
+    def generate_candidates(
+        self,
+        raw_mention_text: str,
+        *,
+        context: object = None,
+        limit: int = 10,
+    ) -> list[FuzzyCandidate]:
+        self.calls.append(raw_mention_text)
+        return list(self._candidates_by_mention.get(raw_mention_text, []))[:limit]
+
+
+def build_fixture() -> ProofFixture:
+    entity_repo = InMemoryEntityRepository()
+    alias_repo = InMemoryAliasRepository()
+    case_repo = InMemoryResolutionCaseRepository()
+    reference_repo = InMemoryResolutionAuditReferenceRepository(case_repo)
+
+    for entity in [
+        _make_stock("ENT_STOCK_600519.SH", "贵州茅台", "600519.SH"),
+        _make_stock("ENT_STOCK_000001.SZ", "平安银行", "000001.SZ"),
+        _make_stock(
+            "ENT_STOCK_300750.SZ",
+            "宁德时代",
+            "300750.SZ",
+            cross_listing_group="CATL",
+        ),
+        _make_stock(
+            "ENT_STOCK_03750.HK",
+            "宁德时代",
+            "03750.HK",
+            cross_listing_group="CATL",
+        ),
+    ]:
+        entity_repo.save(entity)
+
+    for alias in [
+        _make_alias("ENT_STOCK_600519.SH", "贵州茅台", AliasType.SHORT_NAME),
+        _make_alias("ENT_STOCK_600519.SH", "600519", AliasType.CODE),
+        _make_alias("ENT_STOCK_000001.SZ", "平安银行", AliasType.SHORT_NAME),
+        _make_alias("ENT_STOCK_000001.SZ", "000001", AliasType.CODE),
+        _make_alias("ENT_STOCK_300750.SZ", "宁德时代", AliasType.SHORT_NAME),
+        _make_alias("ENT_STOCK_03750.HK", "宁德时代", AliasType.SHORT_NAME),
+    ]:
+        alias_repo.save(alias)
+
+    fuzzy_matcher = InjectedFakeFuzzyMatcher(
+        {
+            "宁德时代新能源": [
+                _make_fuzzy_candidate(
+                    "ENT_STOCK_300750.SZ",
+                    "宁德时代",
+                    0.91,
+                ),
+                _make_fuzzy_candidate(
+                    "ENT_STOCK_03750.HK",
+                    "宁德时代",
+                    0.89,
+                ),
+            ],
+        }
+    )
+    return ProofFixture(
+        entity_repo=entity_repo,
+        alias_repo=alias_repo,
+        reference_repo=reference_repo,
+        case_repo=case_repo,
+        fuzzy_matcher=fuzzy_matcher,
+    )
+
+
+def run_proof() -> dict[str, Any]:
+    fixture = build_fixture()
+    case_summaries = [
+        _run_case(
+            fixture,
+            name="deterministic_exact",
+            mention="贵州茅台",
+            context={"document_id": "m4-8-proof-exact"},
+            expected_entity_id="ENT_STOCK_600519.SH",
+            expected_method=ResolutionMethod.DETERMINISTIC,
+            expected_decision_type=DecisionType.AUTO,
+            expected_candidate_ids=["ENT_STOCK_600519.SH"],
+        ),
+        _run_case(
+            fixture,
+            name="deterministic_code",
+            mention="000001",
+            context={"document_id": "m4-8-proof-code"},
+            expected_entity_id="ENT_STOCK_000001.SZ",
+            expected_method=ResolutionMethod.DETERMINISTIC,
+            expected_decision_type=DecisionType.AUTO,
+            expected_candidate_ids=["ENT_STOCK_000001.SZ"],
+        ),
+        _run_case(
+            fixture,
+            name="deterministic_rule",
+            mention="600519.SH",
+            context={"document_id": "m4-8-proof-rule"},
+            expected_entity_id="ENT_STOCK_600519.SH",
+            expected_method=ResolutionMethod.DETERMINISTIC,
+            expected_decision_type=DecisionType.AUTO,
+            expected_candidate_ids=["ENT_STOCK_600519.SH"],
+        ),
+        _run_case(
+            fixture,
+            name="ambiguous_fuzzy_candidate",
+            mention="宁德时代新能源",
+            context={"document_id": "m4-8-proof-fuzzy"},
+            expected_entity_id=None,
+            expected_method=ResolutionMethod.UNRESOLVED,
+            expected_decision_type=DecisionType.MANUAL_REVIEW,
+            expected_candidate_ids=[
+                "ENT_STOCK_300750.SZ",
+                "ENT_STOCK_03750.HK",
+            ],
+        ),
+        _run_case(
+            fixture,
+            name="unresolved_fail_closed",
+            mention="不存在的公司",
+            context={"document_id": "m4-8-proof-unresolved"},
+            expected_entity_id=None,
+            expected_method=ResolutionMethod.UNRESOLVED,
+            expected_decision_type=DecisionType.AUTO,
+            expected_candidate_ids=[],
+        ),
+    ]
+
+    _assert_equal(
+        "fake fuzzy calls",
+        fixture.fuzzy_matcher.calls,
+        ["宁德时代新能源", "不存在的公司"],
+    )
+
+    return {
+        "proof": "m4.8-focused-resolution-proof",
+        "case_count": len(case_summaries),
+        "cases": case_summaries,
+        "audit_payload_verified": all(
+            item["audit_payload_verified"] for item in case_summaries
+        ),
+        "contract_projection_verified": all(
+            item["contract_projection_verified"] for item in case_summaries
+        ),
+        "fuzzy_backend": "injected_fake",
+        "core_library_changes_required": False,
+        "productionization_pending": [
+            "durable repository adapter wiring",
+            "external fuzzy backend implementation",
+            "larger fixture coverage",
+        ],
+    }
+
+
+def _run_case(
+    fixture: ProofFixture,
+    *,
+    name: str,
+    mention: str,
+    context: dict[str, object],
+    expected_entity_id: str | None,
+    expected_method: ResolutionMethod,
+    expected_decision_type: DecisionType,
+    expected_candidate_ids: list[str],
+) -> dict[str, Any]:
+    result = resolve_mention_with_repositories(
+        mention,
+        context,
+        entity_repo=fixture.entity_repo,
+        alias_repo=fixture.alias_repo,
+        reference_repo=fixture.reference_repo,
+        case_repo=fixture.case_repo,
+        fuzzy_matcher=fixture.fuzzy_matcher,
+    )
+    reference = _latest_reference_for_mention(fixture.reference_repo, mention)
+    payload = get_resolution_audit_payload(
+        reference.reference_id,
+        reference_repo=fixture.reference_repo,
+        case_repo=fixture.case_repo,
+    )
+    case = payload.resolution_case
+    candidate_entities = [
+        _require_entity(fixture.entity_repo, entity_id)
+        for entity_id in case.candidate_entity_ids
+    ]
+    contract_case = to_contract_resolution_case(
+        case,
+        input_alias=mention,
+        candidate_entities=candidate_entities,
+        decision=(
+            EntityResolutionDecision.MATCHED
+            if expected_entity_id is not None
+            else EntityResolutionDecision.UNRESOLVED
+        ),
+        resolved_entity=(
+            None
+            if expected_entity_id is None
+            else _require_entity(fixture.entity_repo, expected_entity_id)
+        ),
+        confidence=result.resolution_confidence,
+    )
+
+    _assert_equal(
+        f"{name} result entity",
+        result.resolved_entity_id,
+        expected_entity_id,
+    )
+    _assert_equal(f"{name} result method", result.resolution_method, expected_method)
+    _assert_equal(
+        f"{name} reference entity",
+        reference.resolved_entity_id,
+        expected_entity_id,
+    )
+    _assert_equal(
+        f"{name} reference method",
+        reference.resolution_method,
+        expected_method,
+    )
+    _assert_equal(f"{name} case selected", case.selected_entity_id, expected_entity_id)
+    _assert_equal(f"{name} case decision", case.decision_type, expected_decision_type)
+    _assert_equal(
+        f"{name} candidates",
+        case.candidate_entity_ids,
+        expected_candidate_ids,
+    )
+    _assert_equal(f"{name} payload reference", payload.entity_reference, reference)
+    _assert_equal(
+        f"{name} payload unresolved",
+        payload.unresolved,
+        expected_entity_id is None,
+    )
+    _assert_equal(f"{name} contract input", contract_case.input_alias, mention)
+    _assert_equal(
+        f"{name} contract evidence",
+        contract_case.evidence_refs,
+        [reference.reference_id],
+    )
+
+    return {
+        "name": name,
+        "mention": mention,
+        "resolved_entity_id": result.resolved_entity_id,
+        "resolution_method": result.resolution_method.value,
+        "resolution_confidence": result.resolution_confidence,
+        "decision_type": case.decision_type.value,
+        "candidate_entity_ids": list(case.candidate_entity_ids),
+        "audit_payload_verified": True,
+        "contract_projection_verified": True,
+        "auto_selected": case.selected_entity_id is not None,
+    }
+
+
+def _latest_reference_for_mention(
+    reference_repo: InMemoryResolutionAuditReferenceRepository,
+    mention: str,
+) -> EntityReference:
+    references = [
+        reference
+        for reference in reference_repo._references.values()
+        if reference.raw_mention_text == mention
+    ]
+    if not references:
+        raise AssertionError(f"missing reference for mention: {mention}")
+    return max(references, key=lambda reference: reference.created_at)
+
+
+def _make_stock(
+    entity_id: str,
+    display_name: str,
+    anchor_code: str,
+    *,
+    cross_listing_group: str | None = None,
+) -> CanonicalEntity:
+    return CanonicalEntity(
+        canonical_entity_id=entity_id,
+        entity_type=EntityType.STOCK,
+        display_name=display_name,
+        status=EntityStatus.ACTIVE,
+        anchor_code=anchor_code,
+        cross_listing_group=cross_listing_group,
+    )
+
+
+def _make_alias(
+    entity_id: str,
+    alias_text: str,
+    alias_type: AliasType,
+) -> EntityAlias:
+    return EntityAlias(
+        canonical_entity_id=entity_id,
+        alias_text=alias_text,
+        alias_type=alias_type,
+        confidence=1.0,
+        source="m4.8-proof-fixture",
+        is_primary=alias_type is not AliasType.CODE,
+    )
+
+
+def _make_fuzzy_candidate(
+    entity_id: str,
+    alias_text: str,
+    score: float,
+) -> FuzzyCandidate:
+    return FuzzyCandidate(
+        canonical_entity_id=entity_id,
+        alias_text=alias_text,
+        alias_type=AliasType.SHORT_NAME,
+        score=score,
+        source="m4.8-proof-fake-fuzzy",
+        blocking_key=alias_text[:2],
+    )
+
+
+def _require_entity(
+    entity_repo: InMemoryEntityRepository,
+    entity_id: str,
+) -> CanonicalEntity:
+    entity = entity_repo.get(entity_id)
+    if entity is None:
+        raise AssertionError(f"missing fixture entity: {entity_id}")
+    return entity
+
+
+def _assert_equal(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def _write_summary(summary: dict[str, Any], path: Path | None) -> None:
+    rendered = json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True)
+    if path is None:
+        print(rendered)
+        return
+    path.write_text(rendered + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        help="Optional path for writing the stable JSON proof summary.",
+    )
+    args = parser.parse_args(argv)
+    summary = run_proof()
+    _write_summary(summary, args.summary_json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/proof/__init__.py
+++ b/tests/proof/__init__.py
@@ -1,0 +1,1 @@
+"""Focused proof tests."""

--- a/tests/proof/test_m4_8_focused_resolution_proof.py
+++ b/tests/proof/test_m4_8_focused_resolution_proof.py
@@ -1,0 +1,121 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.m4_8_focused_resolution_proof import run_proof
+
+
+PROOF_SCRIPT = Path("scripts/m4_8_focused_resolution_proof.py")
+
+
+def test_runner_summary_shape_is_stable() -> None:
+    summary = run_proof()
+
+    assert summary["proof"] == "m4.8-focused-resolution-proof"
+    assert summary["case_count"] == 5
+    assert summary["audit_payload_verified"] is True
+    assert summary["contract_projection_verified"] is True
+    assert summary["core_library_changes_required"] is False
+    assert [case["name"] for case in summary["cases"]] == [
+        "deterministic_exact",
+        "deterministic_code",
+        "deterministic_rule",
+        "ambiguous_fuzzy_candidate",
+        "unresolved_fail_closed",
+    ]
+
+
+def test_deterministic_exact_code_and_rule_hits_are_resolved() -> None:
+    summary = run_proof()
+    cases = {case["name"]: case for case in summary["cases"]}
+
+    assert cases["deterministic_exact"] == {
+        "name": "deterministic_exact",
+        "mention": "贵州茅台",
+        "resolved_entity_id": "ENT_STOCK_600519.SH",
+        "resolution_method": "deterministic",
+        "resolution_confidence": 1.0,
+        "decision_type": "auto",
+        "candidate_entity_ids": ["ENT_STOCK_600519.SH"],
+        "audit_payload_verified": True,
+        "contract_projection_verified": True,
+        "auto_selected": True,
+    }
+    assert cases["deterministic_code"]["resolved_entity_id"] == "ENT_STOCK_000001.SZ"
+    assert cases["deterministic_code"]["resolution_method"] == "deterministic"
+    assert cases["deterministic_code"]["candidate_entity_ids"] == [
+        "ENT_STOCK_000001.SZ"
+    ]
+    assert cases["deterministic_rule"]["resolved_entity_id"] == "ENT_STOCK_600519.SH"
+    assert cases["deterministic_rule"]["resolution_method"] == "deterministic"
+
+
+def test_ambiguous_fuzzy_candidates_are_not_auto_selected() -> None:
+    summary = run_proof()
+    ambiguous = _case(summary, "ambiguous_fuzzy_candidate")
+
+    assert ambiguous["resolved_entity_id"] is None
+    assert ambiguous["resolution_method"] == "unresolved"
+    assert ambiguous["resolution_confidence"] is None
+    assert ambiguous["decision_type"] == "manual_review"
+    assert ambiguous["candidate_entity_ids"] == [
+        "ENT_STOCK_300750.SZ",
+        "ENT_STOCK_03750.HK",
+    ]
+    assert ambiguous["auto_selected"] is False
+
+
+def test_unresolved_fail_closed_has_no_synthetic_candidate() -> None:
+    summary = run_proof()
+    unresolved = _case(summary, "unresolved_fail_closed")
+
+    assert unresolved["resolved_entity_id"] is None
+    assert unresolved["resolution_method"] == "unresolved"
+    assert unresolved["decision_type"] == "auto"
+    assert unresolved["candidate_entity_ids"] == []
+    assert unresolved["auto_selected"] is False
+
+
+def test_audit_payload_and_contract_projection_are_verified_per_case() -> None:
+    summary = run_proof()
+
+    for case in summary["cases"]:
+        assert case["audit_payload_verified"] is True
+        assert case["contract_projection_verified"] is True
+
+
+def test_summary_uses_injected_fake_fuzzy_backend_without_production_claim() -> None:
+    summary = run_proof()
+    serialized = json.dumps(summary, ensure_ascii=False).lower()
+
+    assert summary["fuzzy_backend"] == "injected_fake"
+    assert "splink" not in serialized
+    assert "production" not in summary["fuzzy_backend"].lower()
+
+
+def test_script_writes_stdout_and_summary_json(tmp_path: Path) -> None:
+    output_path = tmp_path / "summary.json"
+
+    stdout_run = subprocess.run(
+        [sys.executable, str(PROOF_SCRIPT)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    file_run = subprocess.run(
+        [sys.executable, str(PROOF_SCRIPT), "--summary-json", str(output_path)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    stdout_summary = json.loads(stdout_run.stdout)
+    file_summary = json.loads(output_path.read_text(encoding="utf-8"))
+    assert stdout_summary == run_proof()
+    assert file_summary == run_proof()
+    assert file_run.stdout == ""
+
+
+def _case(summary: dict, name: str) -> dict:
+    return next(case for case in summary["cases"] if case["name"] == name)


### PR DESCRIPTION
## Summary

Adds an M4.8 focused proof harness around the existing entity-registry resolution chain. The harness uses in-memory repositories plus an injected fake fuzzy matcher to verify deterministic exact/code/rule hits, ambiguous fuzzy candidates that remain unresolved for review, unresolved fail-closed behavior, runtime ResolutionCase records, review audit payloads, and contracts projection.

Also updates README and docs/PROGRESS.md to remove the stale scaffold-only status and adds an evidence note for the proof scope and non-goals.

## Boundaries

- No contracts changes.
- No holdings subtype.
- No new core resolver capability.
- No claim that the placeholder fuzzy adapter is production-ready.

## Validation

- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src .venv/bin/python -m pytest -q -p no:cacheprovider tests/test_resolution_deterministic.py tests/test_resolution_fuzzy.py tests/test_resolution_resolve_mention.py tests/test_resolution_llm.py tests/test_references.py tests/test_contracts_alignment.py tests/boundary tests/proof/test_m4_8_focused_resolution_proof.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src:../contracts/src .venv/bin/python scripts/m4_8_focused_resolution_proof.py
- .venv/bin/python -m py_compile scripts/m4_8_focused_resolution_proof.py
- git diff --check origin/main...HEAD
- git diff --check
